### PR TITLE
Add functionality to locally "mute" players in online sessions

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -2567,6 +2567,7 @@ void CL_RemovePlayer(INT32 playernum, kickreason_t reason)
 			nodeingame[node] = false;
 			Net_CloseConnection(node);
 			ResetNode(node);
+			UnmutePlayerFromChat(node);
 		}
 	}
 
@@ -3349,6 +3350,7 @@ void SV_ResetServer(void)
 	memset(playerdelaytable, 0, sizeof playerdelaytable);
 
 	ClearAdminPlayers();
+	ClearMutedPlayers();
 	Schedule_Clear();
 	Automate_Clear();
 	K_ClearClientPowerLevels();
@@ -3454,6 +3456,7 @@ void D_QuitNetGame(void)
 
 	D_CloseConnection();
 	ClearAdminPlayers();
+	ClearMutedPlayers(); // RadioRacers - self-explanatory.
 	Schedule_Clear();
 	Automate_Clear();
 	K_ClearClientPowerLevels();

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1347,9 +1347,13 @@ static boolean AddIWAD(void)
 	}
 }
 
+// RadioRacers: Custom optional addons for miscelleanous additions
+boolean found_radioracers;
+boolean radioracers_usemuteicons = false;
 static void IdentifyVersion(void)
 {
 	const char *srb2waddir = NULL;
+	found_radioracers = false;
 
 #if (defined (__unix__) && !defined (MSDOS)) || defined (UNIXCOMMON) || defined (HAVE_SDL)
 	// change to the directory where 'bios.pk3' is found
@@ -1396,6 +1400,12 @@ static void IdentifyVersion(void)
 #ifdef USE_PATCH_FILE
 	D_AddFile(startupiwads, va(pandf,srb2waddir,"patch.pk3"));
 #endif
+
+	// RadioRacers: Test
+	if (FIL_ReadFileOK(va(pandf,srb2waddir,"radioracers.wad"))) {
+		D_AddFile(startupiwads, va(pandf,srb2waddir,"radioracers.wad"));
+		found_radioracers = true;
+	}
 
 #define MUSICTEST(str) \
 	{\
@@ -1738,6 +1748,17 @@ void D_SRB2Main(void)
 #endif
 
 #endif //ifndef DEVELOP
+
+	if(found_radioracers)
+		mainwads++;
+
+	//RadioRacers: Mute icon for Pause Menu
+	/**
+	 * Apparently, W_CheckMultipleLumps just got taken out of this source code? Despite being such a helpful utility function. Noire adds it back as a library, but this fork doesn't need that .. for now.
+	 */
+	if (W_LumpExists("M_ICOMUT") && W_LumpExists( "M_ICOMU2")) {
+		radioracers_usemuteicons = true;
+	}
 
 	// Load credits_def lump
 	F_LoadCreditsDefinitions();

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -32,6 +32,10 @@ extern const char *pandf; //Alam: how to path?
 extern char srb2path[256]; //Alam: SRB2's Home
 extern char addonsdir[MAX_WADPATH]; // Where addons are stored
 
+// RadioRacers: Test
+extern boolean found_radioracers;
+extern boolean radioracers_usemuteicons;
+
 // the infinite loop of D_SRB2Loop() called from win_main for windows version
 void D_SRB2Loop(void) FUNCNORETURN;
 

--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -259,6 +259,7 @@ boolean forcespecialstage = false;
 
 UINT8 splitscreen = 0;
 INT32 adminplayers[MAXPLAYERS];
+INT32 mutedplayers[MAXPLAYERS]; // RadioRacers: check doomstat.h for more information.
 
 // Scheduled commands.
 scheduleTask_t **schedule = NULL;
@@ -3952,6 +3953,49 @@ void ClearAdminPlayers(void)
 {
 	memset(adminplayers, -1, sizeof(adminplayers));
 }
+
+void MutePlayerFromChat(INT32 playernum) {
+	INT32 i;
+	for (i = 0; i < MAXPLAYERS; i++)
+	{
+		if (playernum == mutedplayers[i])
+			return; // Player is already muted
+		
+		if (mutedplayers[i] == -1) {
+			mutedplayers[i] = playernum;
+			break;			
+		}
+	}
+}
+
+void UnmutePlayerFromChat(INT32 playernum) {
+	INT32 i;
+	for (i = 0; i < MAXPLAYERS; i++)
+	{
+		if (mutedplayers[i] == playernum) {
+			mutedplayers[i] = -1;
+			break;			
+		}
+	}
+}
+
+boolean IsPlayerMuted(INT32 playernum) 
+{
+	INT32 i;
+	for (i = 0; i < MAXPLAYERS; i++)
+	{
+		if (playernum == mutedplayers[i]) {
+			return true;
+		}
+	}	
+	return false;
+}
+
+void ClearMutedPlayers(void)
+{
+	memset(mutedplayers, -1, sizeof(mutedplayers));
+}
+
 
 void RemoveAdminPlayer(INT32 playernum)
 {

--- a/src/d_netcmd.h
+++ b/src/d_netcmd.h
@@ -259,6 +259,13 @@ void RemoveAdminPlayer(INT32 playernum);
 void ItemFinder_OnChange(void);
 void D_SetPassword(const char *pw);
 
+// RadioRacers
+void ClearMutedPlayers(void); // Clear the muted players array at the end of a netgame.
+void MutePlayerFromChat(INT32 playernum); // Mute a player from chat.
+void UnmutePlayerFromChat(INT32 playernum); // Unmute a player from chat.
+boolean IsPlayerMuted(INT32 playernum); // Check if a player node is in the 'muted players' array
+
+
 struct scheduleTask_t
 {
 	UINT16 basetime;

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -957,6 +957,7 @@ extern consvar_t cv_jointimeout;
 extern ticcmd_t netcmds[BACKUPTICS][MAXPLAYERS];
 extern INT32 serverplayer;
 extern INT32 adminplayers[MAXPLAYERS];
+extern INT32 mutedplayers[MAXPLAYERS]; // RadioRacers: Array to store nodes of muted players in netgames
 
 /// \note put these in d_clisrv outright?
 

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -185,7 +185,6 @@ static void Command_Sayteam_f(void);
 static void Command_CSay_f(void);
 static void Command_Shout(void);
 static void Command_MutePlayer(void); // RadioRacers - mute player command
-static void Command_ShowMutedPlayers(void); // RadioRacers - mute player command
 static void Got_Saycmd(const UINT8 **p, INT32 playernum);
 
 void HU_LoadGraphics(void)
@@ -238,7 +237,6 @@ void HU_Init(void)
 	COM_AddCommand("csay", Command_CSay_f);
 	COM_AddCommand("shout", Command_Shout);
 	COM_AddCommand("muteplayer", Command_MutePlayer); // RadioRacers - muteplayer command
-	COM_AddCommand("showmutedplayers", Command_ShowMutedPlayers);
 	RegisterNetXCmd(XD_SAY, Got_Saycmd);
 
 	// only allocate if not present, to save us a lot of headache
@@ -668,20 +666,6 @@ static void Command_Shout(void)
 	DoSayPacketFromCommand(0, 1, HU_SHOUT);
 }
 
-static void Command_ShowMutedPlayers(void)
-{
-
-	INT32 i;
-	for (i = 0; i < MAXPLAYERS; i++)
-	{
-		if (playeringame[i])
-		{
-			CONS_Printf("Node %d: %*s", i, (int)i, player_names[i]);
-			CONS_Printf("[%s]", (mutedplayers[i] == -1 ? "UNMUTED" : "MUTED"));
-			CONS_Printf("\n");
-		}
-	}
-}
 /** RadioRacers: Locally mute a player in a netgame.
 */
 static void Command_MutePlayer(void)
@@ -736,6 +720,12 @@ static void Command_MutePlayer(void)
 	// Attempting to mute the server host. Administrators are fine, though.
 	if (target == serverplayer) {
 		CONS_Alert(CONS_NOTICE, M_GetText("You cannot mute the server host.\n"));
+		return;
+	}
+
+	// Attempting to mute .. a bot?
+	if (players[target].bot) {
+		CONS_Alert(CONS_NOTICE, M_GetText("Bots don't talk!\n"));
 		return;
 	}
 

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -184,6 +184,8 @@ static void Command_Sayto_f(void);
 static void Command_Sayteam_f(void);
 static void Command_CSay_f(void);
 static void Command_Shout(void);
+static void Command_MutePlayer(void); // RadioRacers - mute player command
+static void Command_ShowMutedPlayers(void); // RadioRacers - mute player command
 static void Got_Saycmd(const UINT8 **p, INT32 playernum);
 
 void HU_LoadGraphics(void)
@@ -235,6 +237,8 @@ void HU_Init(void)
 	COM_AddCommand("sayteam", Command_Sayteam_f);
 	COM_AddCommand("csay", Command_CSay_f);
 	COM_AddCommand("shout", Command_Shout);
+	COM_AddCommand("muteplayer", Command_MutePlayer); // RadioRacers - muteplayer command
+	COM_AddCommand("showmutedplayers", Command_ShowMutedPlayers);
 	RegisterNetXCmd(XD_SAY, Got_Saycmd);
 
 	// only allocate if not present, to save us a lot of headache
@@ -664,6 +668,99 @@ static void Command_Shout(void)
 	DoSayPacketFromCommand(0, 1, HU_SHOUT);
 }
 
+static void Command_ShowMutedPlayers(void)
+{
+
+	INT32 i;
+	for (i = 0; i < MAXPLAYERS; i++)
+	{
+		if (playeringame[i])
+		{
+			CONS_Printf("Node %d: %*s", i, (int)i, player_names[i]);
+			CONS_Printf("[%s]", (mutedplayers[i] == -1 ? "UNMUTED" : "MUTED"));
+			CONS_Printf("\n");
+		}
+	}
+}
+/** RadioRacers: Locally mute a player in a netgame.
+*/
+static void Command_MutePlayer(void)
+{
+	/**
+	 * RadioRacers:
+	 * Go through the array of muted players and mute/unmute them, depending on 
+	 * the current muted status.
+	 * 
+	 * If muted, unmute.
+	 * If unmuted, mute.
+	 * 
+	 * You shouldn't be able to mute the server. 
+	 */
+
+	// Not in a netgame.
+	if (!netgame)
+	{
+		CONS_Printf(M_GetText("This only works in a netgame.\n")); // Silly, silly.
+		return;
+	}
+
+	// Not enough arguments.
+	if (COM_Argc() < 2)
+	{
+		CONS_Printf(M_GetText("muteplayer <playername|playernum>: locally mute a player in chat\n"));
+		return;
+	}
+
+	// Player's chat is muted already.
+	if (cv_mute.value) 
+	{
+		CONS_Printf(M_GetText("Your chat is already muted. Behave yourself.\n"));
+	}
+
+	INT32 target;
+
+	// Non-existent player.
+	target = nametonum(COM_Argv(1));
+	if (target == -1)
+	{
+		CONS_Alert(CONS_NOTICE, M_GetText("No player with that name!\n"));
+		return;
+	}
+
+	// Attempting to mute .. yourself.
+	if (P_IsMachineLocalPlayer(&players[target])) {
+		CONS_Alert(CONS_NOTICE, M_GetText("You cannot mute yourself.\n"));
+		return;
+	}
+
+	// Attempting to mute the server host. Administrators are fine, though.
+	if (target == serverplayer) {
+		CONS_Alert(CONS_NOTICE, M_GetText("You cannot mute the server host.\n"));
+		return;
+	}
+
+	// Check if target player is muted or not.
+	boolean isMuted = IsPlayerMuted(target);
+
+	if (isMuted) {
+		UnmutePlayerFromChat(target); // Unmute
+
+		HU_AddChatText(
+			va("\x86*%s \x86has been \x85unmuted\x86. (Only you can see this.)",player_names[target]),
+			false
+		);
+		S_StartSound(NULL, sfx_tmxunx);
+	} else {
+		MutePlayerFromChat(target); // Mute
+
+		HU_AddChatText(
+			va("\x86*%s \x86has been \x83muted\x86. (Only you can see this.)",player_names[target]),
+			false
+		);
+		S_StartSound(NULL, sfx_tmxunx);
+	}
+}
+
 /** Receives a message, processing an ::XD_SAY command.
   * \sa DoSayPacket
   * \author Graue <graue@oceanbase.org>
@@ -740,10 +837,12 @@ static void Got_Saycmd(const UINT8 **p, INT32 playernum)
 	}
 
 	// Show messages sent by you, to you, to your team, or to everyone:
-	if (playernum == consoleplayer // By you
+	// RadioRacers: AND they're not muted
+	if ((playernum == consoleplayer // By you
 	|| (target == -1 && ST_SameTeam(&players[consoleplayer], &players[playernum])) // To your team
 	|| target == 0 // To everyone
-	|| consoleplayer == target-1) // To you
+	|| consoleplayer == target-1)
+	&& !IsPlayerMuted(playernum)) // To you
 	{
 		const char *prefix = "", *cstart = "", *cend = "", *adminchar = "\x82~\x83", *remotechar = "\x82@\x83", *fmt2, *textcolor = "\x80";
 		char *tempchar = NULL;

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -2536,7 +2536,7 @@ void PositionFacesInfo::draw_1p()
 				colormap = R_GetTranslationColormap(workingskin, static_cast<skincolornum_t>(players[rankplayer[i]].mo->color), GTC_CACHE);
 
 			V_DrawMappedPatch(FACE_X + xoff, Y + yoff, V_HUDTRANS|V_SLIDEIN|V_SNAPTOLEFT|flipflag, faceprefix[workingskin][FACE_RANK], colormap);
-
+	
 			if (LUA_HudEnabled(hud_battlebumpers))
 			{
 				const UINT8 bumpers = K_Bumpers(&players[rankplayer[i]]);
@@ -4023,7 +4023,11 @@ void K_DrawPlayerTag(fixed_t x, fixed_t y, player_t *p, playertagtype_t type, IN
 
 	case PLAYERTAG_NAME:
 		K_DrawNameTagForPlayer(x, y, p, flags);
-		K_DrawTypingNotifier(x, y, p, flags);
+
+		// RadioRacers: Don't REALLY need to hide this if a player is muted, but, consistency.
+		if (!IsPlayerMuted(p - players)) {
+			K_DrawTypingNotifier(x, y, p, flags);
+		}
 		break;
 
 	default:

--- a/src/k_menu.h
+++ b/src/k_menu.h
@@ -566,6 +566,7 @@ typedef enum
 	mpause_discordrequests,
 #endif
 	mpause_admin,
+	mpause_muteplayers, // RadioRacers: Yeah.
 	mpause_callvote,
 
 	mpause_giveup,
@@ -1253,14 +1254,30 @@ void M_QuitPauseMenu(INT32 choice);
 boolean M_PauseInputs(INT32 ch);
 void M_PauseTick(void);
 
+
+/**
+ * RadioRacers: Extending this struct by adding another struct which controls the purpose of the kick menu.
+ * Can't think of a solution of reusing the code M_DrawKickHandler without it being needlessly complex or
+ * disgustingly ugly.
+ * 
+ * Better to add edge-cases as and when.
+ * */ 
+typedef enum
+{
+	PKM_KICK = 0,	// Kick another player in the server
+	PKM_MUTE		// (Locally) mute another player in the server
+} playerkickmenu_purpose;
+
 extern struct playerkickmenu_s {
 	tic_t ticker;
 	UINT8 player;
 	UINT8 poke;
 	boolean adminpowered;
+	playerkickmenu_purpose purpose; // RadioRacers: By default, the purpose is to kick someone.
 } playerkickmenu;
 
 void M_KickHandler(INT32 choice);
+void M_MuteHandler(INT32 choice); // RadioRacers: Handler for muting players
 
 extern consvar_t cv_dummymenuplayer;
 extern consvar_t cv_dummyspectator;

--- a/src/k_menudraw.c
+++ b/src/k_menudraw.c
@@ -6159,11 +6159,23 @@ void M_DrawKickHandler(void)
 				player_names[i]
 			);
 
-			V_DrawRightAlignedThinString(
-				x+118, y-2,
-				0,
-				(players[i].spectator) ? "SPECTATOR" : "PLAYING"
-			);
+
+			// RadioRacers: Draw a different tooltip next to the player depending on purpose
+			switch(playerkickmenu.purpose) 
+			{
+				case PKM_KICK:
+					V_DrawRightAlignedThinString(x+118, y-2, 0,
+						(players[i].spectator) ? "SPECTATOR" : "PLAYING"
+					);
+					break;
+				case PKM_MUTE:
+					V_DrawRightAlignedThinString(x+118, y-2, 0,
+						(IsPlayerMuted(i)) ? "\x83MUTED" : "\x85UNMUTED"
+					);
+					break;
+				default:
+					break;
+			}
 		}
 
 		if (i == playerkickmenu.player)
@@ -6190,12 +6202,27 @@ void M_DrawKickHandler(void)
 	//V_DrawFill(32 + (playerkickmenu.player & 8), 32 + (playerkickmenu.player & 7)*8, 8, 8, playeringame[playerkickmenu.player] ? 0 : 16);
 
 	V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName("MENUHINT", PU_CACHE), NULL);
+
+
+	// RadioRacers: Draw a different title depending on the kick menu purpose
+	char *kickMenuTitle = NULL;
+	switch(playerkickmenu.purpose) {
+		case PKM_KICK:
+			kickMenuTitle = (playerkickmenu.adminpowered)
+				? "You are using ""\x85""Admin Tools""\x80"", ""\x83""(A)""\x80"" to kick and ""\x84""(C)""\x80"" to ban"
+				: K_GetMidVoteLabel(menucallvote);
+			break;
+		case PKM_MUTE:
+			kickMenuTitle = "Mute Players - ""\x83(A)""\x80 to toggle.";
+			break;
+		default:
+			kickMenuTitle = "Player Menu";
+	}
+
 	V_DrawCenteredThinString(
 		BASEVIDWIDTH/2, 12,
 		0,
-		(playerkickmenu.adminpowered)
-			? "You are using ""\x85""Admin Tools""\x80"", ""\x83""(A)""\x80"" to kick and ""\x84""(C)""\x80"" to ban"
-			: K_GetMidVoteLabel(menucallvote)
+		kickMenuTitle
 	);
 }
 

--- a/src/k_menudraw.c
+++ b/src/k_menudraw.c
@@ -6169,9 +6169,34 @@ void M_DrawKickHandler(void)
 					);
 					break;
 				case PKM_MUTE:
-					V_DrawRightAlignedThinString(x+118, y-2, 0,
-						(IsPlayerMuted(i)) ? "\x83MUTED" : "\x85UNMUTED"
-					);
+					if (P_IsMachineLocalPlayer(&players[i]))
+						break;
+						
+					if (players[i].bot) {
+						V_DrawRightAlignedThinString(x+116, y-4, 0, "\x88IT'S A BOT");
+					} else {
+						INT32 speechBubbleStart = 103;
+						boolean isMuted = IsPlayerMuted(i);
+						// Speech bubble
+						V_DrawMappedPatch(x+speechBubbleStart, y+8, 
+							(isMuted) ? V_TRANSLUCENT : 0, 
+							W_CachePatchName("K_TALK", PU_CACHE), 
+							NULL);
+
+						patch_t *typingDot = W_CachePatchName("K_TYPDOT", PU_CACHE); // Typing dot
+						if (!isMuted) {
+							int speechBubbleTicker = (leveltime % (8*3)) / 3;
+							if (speechBubbleTicker >= 2) {
+								V_DrawMappedPatch(x+(speechBubbleStart+3), y+8, 0, typingDot, NULL);
+								if (speechBubbleTicker >= 4) {
+									V_DrawMappedPatch(x+(speechBubbleStart+6), y+8, 0, typingDot, NULL);
+									if (speechBubbleTicker >= 6) {
+										V_DrawMappedPatch(x+(speechBubbleStart+9), y+8, 0, typingDot, NULL);
+									}
+								}
+							}
+						}
+					}					
 					break;
 				default:
 					break;

--- a/src/menus/transient/pause-game.c
+++ b/src/menus/transient/pause-game.c
@@ -49,6 +49,10 @@ menuitem_t PAUSE_Main[] =
 	{IT_STRING | IT_ARROWS, "ADMIN TOOLS", "M_ICOADM",
 		NULL, {.routine = M_KickHandler}, 0, 0},
 
+	// RadioRacers: Using the same icon as voting for now.
+	{IT_STRING | IT_ARROWS, "MUTE PLAYERS", "M_ICOADM",
+		NULL, {.routine = M_MuteHandler}, 0, 0}, 
+
 	{IT_STRING | IT_ARROWS, "CALL VOTE", "M_ICOVOT",
 		NULL, {.routine = M_HandlePauseMenuCallVote}, 0, 0},
 
@@ -135,6 +139,7 @@ void M_OpenPauseMenu(void)
 	PAUSE_Main[mpause_switchmap].status = IT_DISABLED;
 	PAUSE_Main[mpause_callvote].status = IT_DISABLED;
 	PAUSE_Main[mpause_admin].status = IT_DISABLED;
+	PAUSE_Main[mpause_muteplayers].status = IT_DISABLED;
 #ifdef HAVE_DISCORDRPC
 	PAUSE_Main[mpause_discordrequests].status = IT_DISABLED;
 #endif
@@ -230,6 +235,8 @@ void M_OpenPauseMenu(void)
 
 			PAUSE_Main[mpause_callvote].status = IT_STRING | IT_ARROWS;
 		}
+		
+		PAUSE_Main[mpause_muteplayers].status = IT_STRING | IT_CALL;
 	}
 
 	if (G_GametypeHasSpectators())

--- a/src/menus/transient/pause-game.c
+++ b/src/menus/transient/pause-game.c
@@ -18,6 +18,7 @@
 #include "../../m_cond.h"
 #include "../../s_sound.h"
 #include "../../k_zvote.h"
+#include "../../d_main.h"
 
 #ifdef HAVE_DISCORDRPC
 #include "../../discord.h"
@@ -25,6 +26,9 @@
 
 // ESC pause menu
 // Since there's no descriptions to each item, we'll use the descriptions as the names of the patches we want to draw for each option :)
+
+// RadioRacers
+char mutePlayersPauseIcon[] = "M_ICOADM";
 
 menuitem_t PAUSE_Main[] =
 {
@@ -50,7 +54,7 @@ menuitem_t PAUSE_Main[] =
 		NULL, {.routine = M_KickHandler}, 0, 0},
 
 	// RadioRacers: Using the same icon as voting for now.
-	{IT_STRING | IT_ARROWS, "MUTE PLAYERS", "M_ICOADM",
+	{IT_STRING | IT_ARROWS, "MUTE PLAYERS", mutePlayersPauseIcon,
 		NULL, {.routine = M_MuteHandler}, 0, 0}, 
 
 	{IT_STRING | IT_ARROWS, "CALL VOTE", "M_ICOVOT",
@@ -117,6 +121,10 @@ void Dummymenuplayer_OnChange(void)
 void M_OpenPauseMenu(void)
 {
 	INT32 i = 0;
+
+	// Radio Racers
+	if (radioracers_usemuteicons)
+		strncpy(mutePlayersPauseIcon, "M_ICOMUT", (sizeof mutePlayersPauseIcon - 1));
 
 	currentMenu = &PAUSE_MainDef;
 

--- a/src/menus/transient/pause-kick.c
+++ b/src/menus/transient/pause-kick.c
@@ -63,6 +63,7 @@ static void M_PlayerMuteHandler(INT32 choice)
 			playeringame[playerkickmenu.player]
 			&& P_IsMachineLocalPlayer(&players[playerkickmenu.player]) == false
 			&& playerkickmenu.player != serverplayer
+			&& !players[playerkickmenu.player].bot
 		)
 		{
 			COM_BufInsertText(va("muteplayer %d\n", playerkickmenu.player));

--- a/src/menus/transient/pause-kick.c
+++ b/src/menus/transient/pause-kick.c
@@ -17,6 +17,63 @@
 
 struct playerkickmenu_s playerkickmenu;
 
+static void M_PlayerMuteHandler(INT32 choice)
+{
+	const UINT8 pid = 0;
+	boolean playerSelected = false;
+
+	// RadioRacers: Still don't understand this variable.
+	(void)choice;
+
+	if (menucmd[pid].dpad_lr != 0) // symmetrical in this case
+	{
+		S_StartSound(NULL, sfx_s3k5b);
+		playerkickmenu.player = ((playerkickmenu.player + 8) % MAXPLAYERS);
+		M_SetMenuDelay(pid);
+	}
+
+	else if (menucmd[pid].dpad_ud > 0)
+	{
+		S_StartSound(NULL, sfx_s3k5b);
+		playerkickmenu.player = ((playerkickmenu.player + 1) & 7) + (playerkickmenu.player & 8);
+		M_SetMenuDelay(pid);
+	}
+
+	else if (menucmd[pid].dpad_ud < 0)
+	{	
+		S_StartSound(NULL, sfx_s3k5b);
+		playerkickmenu.player = ((playerkickmenu.player + 7) & 7) + (playerkickmenu.player & 8);
+		M_SetMenuDelay(pid);
+	}
+
+	else if (M_MenuBackPressed(pid))
+	{
+		M_GoBack(0);
+		M_SetMenuDelay(pid);
+	}
+	else if (M_MenuConfirmPressed(pid))
+	{
+		playerSelected = true;
+	}
+
+	if (playerSelected) {
+		M_SetMenuDelay(pid);
+
+		if (
+			playeringame[playerkickmenu.player]
+			&& P_IsMachineLocalPlayer(&players[playerkickmenu.player]) == false
+			&& playerkickmenu.player != serverplayer
+		)
+		{
+			COM_BufInsertText(va("muteplayer %d\n", playerkickmenu.player));
+			return;
+		}
+
+		playerkickmenu.poke = 8;
+		S_StartSound(NULL, sfx_s3k7b);
+	} 
+}
+
 static void M_PlayerKickHandler(INT32 choice)
 {
 	const UINT8 pid = 0;
@@ -136,9 +193,48 @@ menu_t PAUSE_KickHandlerDef = {
 	NULL,
 };
 
+/**
+ * RadioRacers: These SHOULD go in their own file (e.g. pause-mute.c), but there's a lot of overlap
+ * with the kick handler functionality. Makes sense to leave it in here.
+ * 
+ * Handlers for mute player menu
+ */
+
+static menuitem_t PAUSE_MuteHandler[] =
+{
+	{IT_NOTHING | IT_KEYHANDLER, NULL, NULL, NULL, {.routine = M_PlayerMuteHandler}, 0, 0},
+};
+
+menu_t PAUSE_MuteHandlerDef = {
+	sizeof(PAUSE_MuteHandler) / sizeof(menuitem_t),
+	&PAUSE_MainDef,
+	0,
+	PAUSE_MuteHandler,
+	0, 0,
+	0, 0,
+	0,
+	NULL,
+	0, 0,
+	M_DrawKickHandler,
+	NULL,
+	M_KickHandlerTick, // This can stay the same, it's only handling HUD tickers
+	NULL,
+	NULL,
+	NULL,
+};
+
+void M_MuteHandler(INT32 choice)
+{
+	playerkickmenu.purpose = PKM_MUTE; // RadioRacers: The purpose of the menu is to MUTE players.
+	PAUSE_MuteHandlerDef.prevMenu = currentMenu;
+
+	M_SetupNextMenu(&PAUSE_MuteHandlerDef, true);
+}
+
 void M_KickHandler(INT32 choice)
 {
 	playerkickmenu.adminpowered = (choice >= 0);
+	playerkickmenu.purpose = PKM_KICK; // RadioRacers: The purpose of the menu is to KICK players.
 
 	PAUSE_KickHandlerDef.prevMenu = currentMenu;
 	M_SetupNextMenu(&PAUSE_KickHandlerDef, true);


### PR DESCRIPTION
This functionality is part of the absolute bare _minimum_ that any reasonable player would expect in any online multiplayer game. 
You're already granted the ability to mute the entire chat on your side, but not specifc players.

This PR will add that functionality.

> **This PR also adds an optional check on startup for a `radioracers.wad` addon, where the bespoke icons for the `Mute Players` menu option are housed.**
___
New console command:
* `muteplayer <node>` : 
Mutes a player by their node.

New menu option:
* `Mute Players`:
![image](https://github.com/user-attachments/assets/70db6ca6-7fda-4b87-9fad-0d6a843711c5)
![image](https://github.com/user-attachments/assets/1ec03efe-a208-4d14-af9d-5e77e223b14f)

Reuses the "Kick Player" submenu from the `Admin Tools` menu and `Kick Player` menu options, showing whose muted or not in the lobby.
____
**TL;DR** Locally mute players online in your chatbox.
