### PR TITLE
Vote Snitching

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -593,6 +593,7 @@ if(SRB2_CONFIG_ASAN)
 endif()
 
 add_subdirectory(audio)
+add_subdirectory(radioracers)
 add_subdirectory(core)
 add_subdirectory(hwr2)
 add_subdirectory(io)

--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -35,6 +35,9 @@
 #include "m_fixed.h" // FRACUNIT
 #include "r_skins.h" // DEFAULTSKIN
 
+// RadioRacers
+#include "radioracers/rr_cvar.h"
+
 // There is a memset in one of consvar_t's constructors. It
 // SHOULD be safe if there is no polymorphism, but just
 // double-checking.
@@ -492,6 +495,12 @@ consvar_t precachesound = Player("precachesound", "Off").on_off();
 consvar_t stereoreverse = Player("stereoreverse", "Off").on_off();
 
 
+/**
+ * RadioRacers: cvars for custom miscellanous functionalities
+ */
+
+// Vote Snitch
+consvar_t cv_votesnitch = Player("votesnitch", "On").on_off();
 
 //
 // Server local, also available on dedicated servers.

--- a/src/k_menudraw.c
+++ b/src/k_menudraw.c
@@ -6185,7 +6185,7 @@ void M_DrawKickHandler(void)
 
 						patch_t *typingDot = W_CachePatchName("K_TYPDOT", PU_CACHE); // Typing dot
 						if (!isMuted) {
-							int speechBubbleTicker = (playerkickmenu.ticker % (8*3)) / 3;
+							int speechBubbleTicker = (leveltime % (8*3)) / 3;
 							if (speechBubbleTicker >= 2) {
 								V_DrawMappedPatch(x+(speechBubbleStart+3), y+8, 0, typingDot, NULL);
 								if (speechBubbleTicker >= 4) {

--- a/src/k_menudraw.c
+++ b/src/k_menudraw.c
@@ -6185,7 +6185,7 @@ void M_DrawKickHandler(void)
 
 						patch_t *typingDot = W_CachePatchName("K_TYPDOT", PU_CACHE); // Typing dot
 						if (!isMuted) {
-							int speechBubbleTicker = (leveltime % (8*3)) / 3;
+							int speechBubbleTicker = (playerkickmenu.ticker % (8*3)) / 3;
 							if (speechBubbleTicker >= 2) {
 								V_DrawMappedPatch(x+(speechBubbleStart+3), y+8, 0, typingDot, NULL);
 								if (speechBubbleTicker >= 4) {

--- a/src/k_zvote.c
+++ b/src/k_zvote.c
@@ -26,6 +26,9 @@
 #include "byteptr.h"
 #include "s_sound.h"
 
+// RadioRacers
+#include "radioracers/rr_votesnitch.h"
+
 extern consvar_t cv_zvote_quorum;
 extern consvar_t cv_zvote_spectators;
 extern consvar_t cv_zvote_length;
@@ -313,6 +316,10 @@ static void Got_SetZVote(const UINT8 **cp, INT32 playernum)
 	S_StartSound(NULL, sfx_gshad);
 
 	g_midVote.votes[playernum] = true;
+
+	if (RR_UseVoteSnitch()){
+		RR_VoteSnitchYesVotes(playernum);
+	}
 }
 
 /*--------------------------------------------------
@@ -708,6 +715,11 @@ void K_InitNewMidVote(player_t *caller, midVoteType_e type, INT32 variable, play
 	g_midVote.victim = victim;
 
 	S_StartSound(NULL, sfx_cdfm67);
+
+	// RadioRacers: Finally...
+	if (RR_UseVoteSnitch()){
+		RR_VoteSnitchNewVote(type, victim, caller);
+	}
 
 	g_midVote.votes[caller - players] = true;
 

--- a/src/radioracers/CMakeLists.txt
+++ b/src/radioracers/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(netgame)

--- a/src/radioracers/netgame/CMakeLists.txt
+++ b/src/radioracers/netgame/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(SRB2SDL2 PRIVATE
+	rr_votesnitch.c
+)

--- a/src/radioracers/netgame/rr_votesnitch.c
+++ b/src/radioracers/netgame/rr_votesnitch.c
@@ -1,0 +1,73 @@
+// RadioRacers
+//-----------------------------------------------------------------------------
+// Copyright (C) 2024 by $HOME
+//
+// This program is free software distributed under the
+// terms of the GNU General Public License, version 2.
+// See the 'LICENSE' file for more details.
+//-----------------------------------------------------------------------------
+/// \file radioracers/netgame/rr_votesnitch.c
+/// \brief Vote Snitching - print out vote statuses in chat
+
+#include "../rr_cvar.h"
+#include "../rr_votesnitch.h"
+
+#include "../../k_hud.h"
+#include "../../g_game.h"
+#include "../../hu_stuff.h"
+#include "../../k_zvote.h"
+
+boolean RR_UseVoteSnitch(void)
+{
+    return (cv_votesnitch.value);
+}
+
+// Who did it? Huh? Who's the filthy CUNT who voted redo for the fourth time in the row...
+void RR_VoteSnitchNewVote(midVoteType_e type, player_t *victim, player_t *caller)
+{
+    const char *voteReason;
+	const char *levelTitle = mapheaderinfo[gamemap-1]->lvlttl;
+	switch (type){
+		case MVT_KICK: // Kick
+			voteReason = va("\x82KICK \x89%s \x86", player_names[victim - players]);
+			break;
+		case MVT_RTV: // Skip
+			if (*levelTitle != '\0') {
+				voteReason = va("\x82SKIP \x89%s", levelTitle);
+			} else {
+				voteReason = "\x82SKIP \x86the current level";
+			}
+			break;
+		case MVT_RUNITBACK: // Redo
+			if (*levelTitle != '\0') {
+				voteReason = va("\x82REDO \x89%s", levelTitle);
+			} else {
+				voteReason = "\x82REDO \x86the current level";
+			}
+			break;
+		default:
+			return;
+	}
+
+	char *newVoteReason = strdup(voteReason);
+
+    // e.g. [VOTE]: Player voted to REDO Death Egg.
+    // e.g. [VOTE]: Player voted to SKIP Death Egg.
+    // e.g. [VOTE]: Player voted to KICK Someone.
+	HU_AddChatText(
+		va("\x86[\x89VOTE\x86]: \x82%s\x86 voted to %s\x86.", player_names[caller - players], newVoteReason), 
+		true
+	);
+}
+
+// .. and WHO are the fuckers who keep voting yes?
+void RR_VoteSnitchYesVotes(INT32 playernum)
+{
+    // e.g. [VOTE]: SlamDunk voted yes.
+    if (playeringame[playernum]) {		
+		HU_AddChatText(
+			va("\x86[\x89VOTE\x86]: \x82%s\x86 voted \x82yes\x86.", player_names[playernum]), 
+			true
+		);
+	}
+}

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -1,0 +1,31 @@
+// RadioRacers
+//-----------------------------------------------------------------------------
+// Copyright (C) 2024 by $HOME
+//
+// This program is free software distributed under the
+// terms of the GNU General Public License, version 2.
+// See the 'LICENSE' file for more details.
+//-----------------------------------------------------------------------------
+/// \file radioracers/rr_cvar.h
+/// \brief RadioRacers CVARs
+
+// Separating custom functionality into new header and source code files is so much cleaner.    
+
+#ifndef __RR_CVAR__
+#define __RR_CVAR__
+
+// consvar_t
+#include "../command.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Player (Clientside)
+extern consvar_t cv_votesnitch;     // Vote Snitch
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif

--- a/src/radioracers/rr_votesnitch.h
+++ b/src/radioracers/rr_votesnitch.h
@@ -1,0 +1,30 @@
+// RadioRacers
+//-----------------------------------------------------------------------------
+// Copyright (C) 2024 by $HOME
+//
+// This program is free software distributed under the
+// terms of the GNU General Public License, version 2.
+// See the 'LICENSE' file for more details.
+//-----------------------------------------------------------------------------
+/// \file radioracers/netgame/rr_votesnitch.h
+/// \brief Vote Snitching - Functions
+
+#ifndef __RR_VOTESNITCH__
+#define _RR_VOTESNITCH__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "../k_hud.h"
+#include "../g_game.h"
+#include "../k_zvote.h"
+
+boolean RR_UseVoteSnitch(void);
+void RR_VoteSnitchNewVote(midVoteType_e type, player_t *victim, player_t *caller);
+void RR_VoteSnitchYesVotes(INT32 playernum);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+#endif


### PR DESCRIPTION
```
>play online
>get shit map
>finish race
>"finally, it's over"
>BRNNNGG
>redo vote
>passes instantly
>🙄
>do race again
>"finally, it's over...."
>BRNNNNG
>redo vote
>passes instantly
```
Making it so that the whole lobby can see who started the vote will make this build incompatible with vanilla. So, for now, it's **clientside**.

Why are server votes even anonymous? At the very least, server admins/hosts should be able to see that. But no one? Come on, now.
___

New CVAR:
* ```votesnitch <On|Off>```:
Self-explanatory. Turns the snitching on and off.

Prints out to the chatbox:

* Which player started the vote 
* What type of vote it is and its relevant information (e.g. Which level has been voted to skip)
* Who the vote will affect (such as problematic players [i.e. you] who have been voted to be kicked)
* Who voted in favour of the vote

![vote_snitch](https://github.com/user-attachments/assets/49486c33-9a32-4471-8590-cbab87901e4f)

Taking a page from [Noire](https://github.com/NepDisk/RingRacers-Noire)'s book for separating custom functionality and variables into separate header files and source files. Much more cleaner.