### PR TITLE
Fix typing dot indicators not animating on 'Mute Players' menu during intermission

### DIFF
--- a/src/k_menudraw.c
+++ b/src/k_menudraw.c
@@ -6185,7 +6185,7 @@ void M_DrawKickHandler(void)
 
 						patch_t *typingDot = W_CachePatchName("K_TYPDOT", PU_CACHE); // Typing dot
 						if (!isMuted) {
-							int speechBubbleTicker = (leveltime % (8*3)) / 3;
+							int speechBubbleTicker = (playerkickmenu.ticker % (8*3)) / 3;
 							if (speechBubbleTicker >= 2) {
 								V_DrawMappedPatch(x+(speechBubbleStart+3), y+8, 0, typingDot, NULL);
 								if (speechBubbleTicker >= 4) {


### PR DESCRIPTION
The typing dot indicators will normally animate during gameplay, using `leveltime` as a ticker to control the animation.
However, during intermissions and voting screens, the indicators will stop animating. This is because `leveltime` isn't incrementing.. because the game's not in a level.

Fixed by using the internal ticker in the `playerkickmenu` struct instead.