### PR TITLE
More Controller Rumble Events

### DIFF
--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -501,6 +501,8 @@ consvar_t stereoreverse = Player("stereoreverse", "Off").on_off();
 
 // Vote Snitch
 consvar_t cv_votesnitch = Player("votesnitch", "On").on_off();
+// More Rumble Events
+consvar_t cv_morerumbleevents = Player("morerumbleevents", "On").on_off();
 
 //
 // Server local, also available on dedicated servers.

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -72,6 +72,11 @@
 // comeback is Battle Mode's karma comeback, also bool
 // mapreset is set when enough players fill an empty server
 
+// RadioRacers: Hacky ways of checking for events the exact FRAME that they happen
+boolean localPlayerJustRingBoosted = false; 	// The second your Ring Boost (TM) timer starts
+boolean localPlayerJustBootyBounced = false; 	// The second you start a fastfall bounce
+boolean localPlayerJustWavedashed = false;		// The few seconds or so your wavedash starts
+
 boolean K_ThunderDome(void)
 {
 	if (K_CanChangeRules(true))
@@ -11202,6 +11207,12 @@ static void K_KartDrift(player_t *player, boolean onground)
 						)
 					);
 
+					// RadioRacers: .. right around here.
+					if (P_IsMachineLocalPlayer(player) && !localPlayerJustWavedashed)
+					{
+						localPlayerJustWavedashed = true;
+					}
+
 					K_SpawnDriftBoostExplosion(player, 0);
 				}
 				S_StopSoundByID(player->mo, sfx_waved1);
@@ -12110,6 +12121,11 @@ boolean K_FastFallBounce(player_t *player)
 		else
 		{
 			S_StartSound(player->mo, sfx_ffbonc);
+			// RadioRacers: .. right around here.
+			if (P_IsMachineLocalPlayer(player) && !localPlayerJustBootyBounced)
+			{
+				localPlayerJustBootyBounced = true;
+			}
 		}
 
 		if (player->mo->eflags & MFE_UNDERWATER)
@@ -13937,6 +13953,12 @@ void K_MoveKartPlayer(player_t *player, boolean onground)
 			}
 		}
 
+	}
+
+	// RadioRacers: Really gross.
+	if (P_IsMachineLocalPlayer(player) && localPlayerJustWavedashed)
+	{
+		localPlayerJustWavedashed = false;
 	}
 
 	K_KartDrift(player, onground);

--- a/src/k_kart.h
+++ b/src/k_kart.h
@@ -279,6 +279,11 @@ boolean K_ThunderDome(void);
 
 boolean K_PlayerCanUseItem(player_t *player);
 
+// RadioRacers: This only works for single-player, no splitscreen. But it can be adapted to work WITH splitscreen easily.
+extern boolean localPlayerJustRingBoosted;
+extern boolean localPlayerJustBootyBounced;
+extern boolean localPlayerJustWavedashed;
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/k_menudraw.c
+++ b/src/k_menudraw.c
@@ -6230,7 +6230,7 @@ void M_DrawKickHandler(void)
 
 
 	// RadioRacers: Draw a different title depending on the kick menu purpose
-	char *kickMenuTitle = NULL;
+	const char *kickMenuTitle = NULL;
 	switch(playerkickmenu.purpose) {
 		case PKM_KICK:
 			kickMenuTitle = (playerkickmenu.adminpowered)

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -3521,6 +3521,14 @@ void A_AttractChase(mobj_t *actor)
 				// Base add is 3 tics for 9,9, adds 1 tic for each point closer to the 1,1 end
 				actor->target->player->ringboost += K_GetKartRingPower(actor->target->player, true) + 3;
 
+				// RadioRacers: .. right around here.
+				if (actor->extravalue1 == 21 && P_IsMachineLocalPlayer(actor->target->player) && !localPlayerJustRingBoosted)
+				{
+					localPlayerJustRingBoosted = true;
+					// Leaving this commented as a reminder
+					// CONS_Printf("ring boost VIBRATE %d\n", g_localplayers[actor->target->player - players]);
+				}
+				
 				S_ReducedVFXSoundAtVolume(actor->target, sfx_s1b5, actor->target->player->ringvolume, NULL);
 
 				if (actor->target->player->rings <= 10 && P_IsDisplayPlayer(actor->target->player))

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -52,6 +52,9 @@
 #include "k_hud.h" // messagetimer
 #include "k_endcam.h"
 
+// RadioRacers
+#include "radioracers/rr_controller.h"
+
 #include "lua_profile.h"
 
 #ifdef PARANOIA
@@ -735,6 +738,9 @@ static inline void P_DeviceRumbleTick(void)
 		UINT16 low = 0;
 		UINT16 high = 0;
 
+		// RadioRacers: Yeah.
+		rumbleevent_e rumbleEvent;
+
 		if (player->mo != NULL && !player->exiting)
 		{
 			if ((player->mo->eflags & MFE_DAMAGEHITLAG) && player->mo->hitlag)
@@ -749,6 +755,14 @@ static inline void P_DeviceRumbleTick(void)
 				&& P_IsObjectOnGround(player->mo) && player->speed != 0)
 			{
 				low = high = 65536 / 32;
+			}
+			else if (
+				RR_ShouldUseMoreRumbleEvents() && 
+				(rumbleEvent = RR_GetRumbleEvent(player)) != 0
+			)
+			{
+				low = high =  RR_GetRumbleStrength(rumbleEvent);
+
 			}
 		}
 

--- a/src/radioracers/CMakeLists.txt
+++ b/src/radioracers/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(netgame)
+add_subdirectory(gameplay)

--- a/src/radioracers/gameplay/CMakeLists.txt
+++ b/src/radioracers/gameplay/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(SRB2SDL2 PRIVATE
+	rr_controllerrumble.c
+)

--- a/src/radioracers/gameplay/rr_controllerrumble.c
+++ b/src/radioracers/gameplay/rr_controllerrumble.c
@@ -1,0 +1,190 @@
+// RadioRacers
+//-----------------------------------------------------------------------------
+// Copyright (C) 2024 by $HOME
+//
+// This program is free software distributed under the
+// terms of the GNU General Public License, version 2.
+// See the 'LICENSE' file for more details.
+//-----------------------------------------------------------------------------
+/// \file radioracers/gameplay/rr_controllerrumble.c
+/// \brief Check for more gameplay conditions to vibrate the player's controller too (e.g. rings)
+
+#include "../rr_cvar.h"
+#include "../rr_controller.h"
+#include "../../doomtype.h"
+#include "../../p_local.h"
+#include "../../p_mobj.h"
+#include "../../d_player.h"
+#include "../../k_kart.h"
+
+boolean RR_ShouldUseMoreRumbleEvents(void)
+{
+    return (cv_morerumbleevents.value);
+}
+
+rumbleevent_e RR_GetRumbleEvent(const player_t* player)
+{
+    if (RR_RumbleJustBumpedWall(player) || RR_RumbleJustFastFallBounced(player))
+    {
+        return EVT_WALL;
+    }
+    else if (RR_RumbleJustDrifted(player))
+    {
+        return EVT_DRIFT;
+    }
+    else if (RR_RumbleIsSpindashingGently(player))
+    {
+        return EVT_SPINDASH_GENTLE;
+    }
+    else if (RR_RumbleIsSpindashingViolently(player))
+    {
+        return EVT_SPINDASH_VIOLENT;
+    }
+    else if (RR_RumbleOverchargingTailWhip(player))
+    {
+        return EVT_WHIP_OVERCHARGING;
+    }
+    else if (RR_RumbleChargingTailWhip(player))
+    {
+        return EVT_WHIP_CHARGING;
+    }
+    else if (RR_RumbleJustWaveDashed(player))
+    {
+        return EVT_WAVEDASHED;
+    }
+    else if (RR_RumbleRingCollected(player) || RR_RumbleRingConsumed(player))
+    {
+        return EVT_RING;
+    }
+
+    return 0;
+}
+
+uint16_t RR_GetRumbleStrength(const rumbleevent_e event)
+{
+    switch (event)
+    {
+        case EVT_WALL:
+            return (65536 / 2);
+        case EVT_WHIP_CHARGING:
+        case EVT_SPINDASH_GENTLE:
+            return (65536 / 25);
+        case EVT_WHIP_OVERCHARGING:
+        case EVT_SPINDASH_VIOLENT:
+            return (65536 / 10);
+        case EVT_WAVEDASHED:
+            return (65536 / 8);
+        case EVT_DRIFT:
+            return (65536 / 100);
+        case EVT_RING:
+            return (65536 / 160); // Way more subtle than stairjank rumble, cos rings can stack
+        default:
+            return 0xFFFF;
+    }
+}
+
+boolean RR_RumbleJustBumpedWall(const player_t *player)
+{
+    return (player->mo->eflags & MFE_JUSTBOUNCEDWALL);
+}
+
+boolean RR_RumbleIsSpindashingGently(const player_t *player)
+{
+    return (
+            P_IsObjectOnGround(player->mo) &&
+            player-> spindash && 
+            player-> spindash < K_GetSpindashChargeTime(player) 
+    );
+}
+
+boolean RR_RumbleIsSpindashingViolently(const player_t *player)
+{
+    return (
+            P_IsObjectOnGround(player->mo) &&
+            player-> spindash && 
+            player-> spindash > K_GetSpindashChargeTime(player) 
+    );
+}
+
+boolean RR_RumbleRingCollected(const player_t *player)
+{
+    return (
+        player->mo && 
+        player->rings < 20 &&
+        player->pickuprings > 0 && player->pickuprings > player->pickuprings-1 && player->pickuprings < player->pickuprings+1
+    );
+}
+
+boolean RR_RumbleChargingTailWhip(const player_t *player)
+{
+    return (
+        (player->mo) &&
+        player->instaWhipCharge != 0 &&
+        player->instaWhipCharge < INSTAWHIP_CHARGETIME
+    );
+}
+
+boolean RR_RumbleOverchargingTailWhip(const player_t *player)
+{
+    return (
+        (player->mo) &&
+        player->instaWhipCharge >= INSTAWHIP_CHARGETIME
+    );
+}
+
+boolean RR_RumbleJustDrifted(const player_t *player)
+{
+    // Charlie, Charlie! Have I told you how much I LOVE repeated code?!
+    const INT32 dsone = K_GetKartDriftSparkValueForStage(player, 1);
+    const INT32 dstwo = K_GetKartDriftSparkValueForStage(player, 2);
+    const INT32 dsthree = K_GetKartDriftSparkValueForStage(player, 3);
+    const INT32 dsfour = K_GetKartDriftSparkValueForStage(player, 4);
+
+    const boolean yellowSparkDrifts = (player->driftcharge >= (dsone - (32*3)) && player-> driftcharge < dsone);
+    const boolean redSparkDrifts = (player->driftcharge >= (dstwo - (32*3)) && player->driftcharge < dstwo);
+    const boolean blueSparkDrifts = (player->driftcharge >= (dsthree - (32*3)) && player->driftcharge < dsthree);
+    const boolean rainbowSparkDrifts = (player->driftcharge >= (dsfour - (32*3)) && player->driftcharge < dsfour);
+    
+    return (
+        player->mo &&
+        player->drift &&
+        (yellowSparkDrifts || redSparkDrifts || blueSparkDrifts || rainbowSparkDrifts)
+    );
+}
+/**
+ * These checks are kind of hacky. 
+ * But I want the rumble to happen the FRAME that the ringboost timer has started.
+ * That way, the player gets feedback immediately and knows when to start adjusting lines
+ * and the sort.
+ */
+boolean RR_RumbleRingConsumed(const player_t *player)
+{
+    const boolean ringJustConsumed = (
+        player->mo &&
+        localPlayerJustRingBoosted
+    );
+
+    if (ringJustConsumed) 
+        localPlayerJustRingBoosted = false;
+
+    return ringJustConsumed;
+}
+
+boolean RR_RumbleJustFastFallBounced(const player_t *player)
+{
+    return (
+        (player-> mo) &&
+        player->fastfall !=0 &&
+        P_IsObjectOnGround(player->mo) && 
+        localPlayerJustBootyBounced
+    );
+}
+
+boolean RR_RumbleJustWaveDashed(const player_t *player)
+{
+    return (
+        (player->mo) &&
+        P_IsObjectOnGround(player->mo) &&
+        localPlayerJustWavedashed
+    );
+}

--- a/src/radioracers/rr_controller.h
+++ b/src/radioracers/rr_controller.h
@@ -1,0 +1,55 @@
+// RadioRacers
+//-----------------------------------------------------------------------------
+// Copyright (C) 2024 by $HOME
+//
+// This program is free software distributed under the
+// terms of the GNU General Public License, version 2.
+// See the 'LICENSE' file for more details.
+//-----------------------------------------------------------------------------
+/// \file radioracers/rr_controller.h
+/// \brief Extended controller rumble events
+
+#ifndef __RR_CONTROLLER__
+#define __RR_CONTROLLER__
+
+#include "../doomtype.h"    // uint16_t
+#include "../d_player.h"    // player_t
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum
+{
+    EVT_WALL = 1,
+    EVT_RING,
+    EVT_SPRUNG,
+    EVT_DRIFT,
+    EVT_WAVEDASHED,
+    EVT_WHIP_CHARGING,
+    EVT_WHIP_OVERCHARGING,
+    EVT_SPINDASH_GENTLE,
+    EVT_SPINDASH_VIOLENT
+} rumbleevent_e ;
+
+extern boolean RR_ShouldUseMoreRumbleEvents(void);
+extern rumbleevent_e RR_GetRumbleEvent(const player_t *player);
+extern uint16_t RR_GetRumbleStrength(const rumbleevent_e event);
+
+// All the event checks
+boolean RR_RumbleJustBumpedWall(const player_t *player);                    // Bumped Wall
+boolean RR_RumbleIsSpindashingGently(const player_t *player);               // Spindashing Gently
+boolean RR_RumbleIsSpindashingViolently(const player_t *player);            // Spindashing Violently
+boolean RR_RumbleRingCollected(const player_t *player);                     // Ring picked up
+boolean RR_RumbleRingConsumed(const player_t *player);                      // Ring used
+boolean RR_RumbleJustDrifted(const player_t *player);                       // Drifts
+boolean RR_RumbleJustFastFallBounced(const player_t *player);               // Fast Fall Bounce
+boolean RR_RumbleJustWaveDashed(const player_t *player);                    // Wavedash/Sliptide
+boolean RR_RumbleChargingTailWhip(const player_t *player);                  // Charging Tailwhip
+boolean RR_RumbleOverchargingTailWhip(const player_t *player);              // Overcharging Tailwhip
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -23,6 +23,7 @@ extern "C" {
 
 // Player (Clientside)
 extern consvar_t cv_votesnitch;     // Vote Snitch
+extern consvar_t cv_morerumbleevents; // Extra gameplay events considered for controller rumble
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
Ring Racers currently checks for the following conditions before rumbling a player's controller:

* Hitlag (e.g. tumble)
* Boosting (e.g. sneaker panels)
* Climbing stairs
* Offroad

Compared to its [predecessor](https://mb.srb2.org/threads/srb2kart.25868/), there's way more stimuli to keep track of with your eyes alone. That's why controller vibrations are helpful.

So, this PR adds the following conditions:
* Wall bump
* Spindash
* Spindash (Overcharge)
* Ring usage
* Ring consumption
* Drift sparks
* Fast fall bounce
* Wavedash
* Tail Whip ™ Charging
* Tail Whip ™ Overcharging

It's also nice being able to _feel_ when you pickup a ring or two. It's immersive ™®. 
Might need to separate these events into individual CVARs.