### PR TITLE
HUD Accessibility Options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "files.associations": {
+        "d_main.h": "c",
+        "rr_menu.h": "c",
+        "command.h": "c",
+        "rr_cvar.h": "c",
+        "i_time.h": "c"
+    }
+}

--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -498,14 +498,24 @@ consvar_t stereoreverse = Player("stereoreverse", "Off").on_off();
 /**
  * RadioRacers: cvars for custom miscellanous functionalities
  */
-
+// How is this basic accessibility option missing from the game? Apalling.
+consvar_t cv_translucenthud = Player("translucenthud", "10").min_max(0, 10);
 // Vote Snitch
 consvar_t cv_votesnitch = Player("votesnitch", "On").on_off();
 // More Rumble Events
 consvar_t cv_morerumbleevents = Player("morerumbleevents", "On").on_off();
 // Rings drawn on player (akin to driftgauge)
-consvar_t cv_ringsonplayer = Player("ringsonplayer", "On").on_off();
+consvar_t cv_ringsonplayer = Player("ringsonplayer", "Vanilla").values({
+	{0, "Vanilla"}, 
+	{1, "Custom"}
+});
 
+// Hide the giant big ass letters at the start of the race
+consvar_t cv_hud_hidecountdown = Player("hidecountdown", "No").yes_no();
+// Hide the bigass position bulbs at the start of the race
+consvar_t cv_hud_hideposition = Player("hideposition", "No").yes_no();
+// Hide the bigass lap emblem when you start a new lap
+consvar_t cv_hud_hidelapemblem = Player("hidelapemblem", "No").yes_no();
 //
 // Server local, also available on dedicated servers.
 // Usually saved, not sycned though...
@@ -1195,9 +1205,26 @@ consvar_t cv_followercolor[MAXSPLITSCREENPLAYERS] = {
 	Player("followercolor4", "Match").values(Followercolor_cons_t).onchange_noinit(Followercolor4_OnChange),
 };
 
+/**
+ * RadioRacers - FOV CVAR INFO
+ * 
+ * Leaivng this here for future work. What I changed here is remove
+ * ".dont_save()" from the CVAR builder for the fov cvar.
+ * 
+ * The ideal change here is to remove the 110 MAX limit on the profile menu.
+ * However, I'm worried about cross-compatability with the vanilla build ..
+ * .. and if the game will say your profile is corrupt if you swap back to 
+ * the vanilla build after using this one.
+ * 
+ * Check 
+ * 	M_ProfileEditApply in options-profiles-edit-1.c 
+ * 	PR_ApplyProfile_Settings in k_profiles.cpp
+ * for more information
+ * 
+ */
 void Fov_OnChange(void);
 consvar_t cv_fov[MAXSPLITSCREENPLAYERS] = {
-	Player("fov", "100").floating_point().min_max(60*FRACUNIT, 179*FRACUNIT).onchange(Fov_OnChange).dont_save(),
+	Player("fov", "100").floating_point().min_max(60*FRACUNIT, 179*FRACUNIT).onchange(Fov_OnChange),
 	Player("fov2", "100").floating_point().min_max(60*FRACUNIT, 179*FRACUNIT).onchange(Fov_OnChange).dont_save(),
 	Player("fov3", "100").floating_point().min_max(60*FRACUNIT, 179*FRACUNIT).onchange(Fov_OnChange).dont_save(),
 	Player("fov4", "100").floating_point().min_max(60*FRACUNIT, 179*FRACUNIT).onchange(Fov_OnChange).dont_save(),

--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -502,8 +502,17 @@ consvar_t stereoreverse = Player("stereoreverse", "Off").on_off();
 consvar_t cv_translucenthud = Player("translucenthud", "10").min_max(0, 10);
 // Vote Snitch
 consvar_t cv_votesnitch = Player("votesnitch", "On").on_off();
-// More Rumble Events
-consvar_t cv_morerumbleevents = Player("morerumbleevents", "On").on_off();
+
+// Rumble Events
+consvar_t cv_morerumbleevents = Player("morerumbleevents", "On").on_off().onchange(RumbleEvents_OnChange);
+consvar_t cv_rr_rumble_wall_bump = Player("rr_rumble_wall_bump", "On").on_off();
+consvar_t cv_rr_rumble_fastfall_bounce = Player("rr_rumble_fastfall_bounce", "On").on_off();
+consvar_t cv_rr_rumble_drift = Player("rr_rumble_drift", "On").on_off();
+consvar_t cv_rr_rumble_spindash = Player("rr_rumble_spindash", "On").on_off();
+consvar_t cv_rr_rumble_tailwhip = Player("rr_rumble_tailwhip", "On").on_off();
+consvar_t cv_rr_rumble_rings = Player("rr_rumble_rings", "On").on_off();
+consvar_t cv_rr_rumble_wavedash = Player("rr_rumble_wavedash", "On").on_off();
+
 // Rings drawn on player (akin to driftgauge)
 consvar_t cv_ringsonplayer = Player("ringsonplayer", "Vanilla").values({
 	{0, "Vanilla"}, 

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -2213,7 +2213,7 @@ void K_DrawKartPositionNumXY(
 	{
 		fx = K_DrawKartPositionNumPatch(
 			(num % 10), splitIndex, color,
-			fx, fy, scale, V_SPLITSCREEN|fflags
+			fx, fy, scale, V_SPLITSCREEN|V_HUDTRANS|fflags
 		);
 		num /= 10;
 	} while (num);
@@ -3106,7 +3106,7 @@ static void K_drawRingCounter(boolean gametypeinfoshown)
 	}
 	else
 	{
-		const boolean DRAW_RINGS_ON_PLAYER = cv_ringsonplayer.value;
+		const boolean DRAW_RINGS_ON_PLAYER = cv_ringsonplayer.value == 1;
 		INT32 ringcounterflags = V_HUDTRANS|V_SLIDEIN|splitflags;
 		INT32 RINGC_X = LAPS_X;
 
@@ -3238,7 +3238,7 @@ static void K_drawRingCounter(boolean gametypeinfoshown)
 static void K_drawKartAccessibilityIcons(boolean gametypeinfoshown, INT32 fx)
 {
 	boolean showbluespheres = (gametyperules & GTR_SPHERES);
-	INT32 fy = LAPS_Y - ((cv_ringsonplayer.value && !showbluespheres && !G_GametypeUsesLives()) ? 0 : 14);
+	INT32 fy = LAPS_Y - ((cv_ringsonplayer.value == 1 && !showbluespheres && !G_GametypeUsesLives()) ? 0 : 14);
     INT32 splitflags = V_SNAPTOLEFT|V_SNAPTOBOTTOM|V_SPLITSCREEN;
 
     boolean mirror = false;
@@ -3352,7 +3352,7 @@ static void K_drawKartSpeedometer(boolean gametypeinfoshown)
 	INT32 splitflags = V_SNAPTOBOTTOM|V_SNAPTOLEFT|V_SPLITSCREEN;
 
 	boolean showbluespheres = (gametyperules & GTR_SPHERES);
-	INT32 fy = LAPS_Y - ((cv_ringsonplayer.value && !showbluespheres && !G_GametypeUsesLives()) ? 0 : 14);
+	INT32 fy = LAPS_Y - ((cv_ringsonplayer.value == 1 && !showbluespheres && !G_GametypeUsesLives()) ? 0 : 14);
 
 	if (battleprisons)
 	{
@@ -4954,7 +4954,7 @@ static void K_drawKartMinimap(void)
 
 static void K_drawKartFinish(boolean finish)
 {
-	INT32 timer, minsplitstationary, pnum = 0, splitflags = V_SPLITSCREEN;
+	INT32 timer, minsplitstationary, pnum = 0, splitflags = V_SPLITSCREEN|V_HUDTRANS;
 	patch_t **kptodraw;
 
 	if (finish)
@@ -5137,7 +5137,7 @@ static void K_drawKartStartBulbs(void)
 			}
 		}
 
-		V_DrawFixedPatch(x, y, FRACUNIT, V_SNAPTOTOP|V_SPLITSCREEN,
+		V_DrawFixedPatch(x, y, FRACUNIT, V_SNAPTOTOP|V_SPLITSCREEN|V_HUDTRANS,
 			(r_splitscreen ? kp_prestartbulb_split[patchnum] : kp_prestartbulb[patchnum]), NULL);
 		x += spacing;
 	}
@@ -5193,11 +5193,17 @@ static void K_drawKartStartCountdown(void)
 
 	if (leveltime >= introtime && leveltime < starttime-(3*TICRATE))
 	{
+		if (cv_hud_hideposition.value)
+			return;
+		
 		if (numbulbs > 1)
 			K_drawKartStartBulbs();
 	}
 	else
 	{
+
+		if (cv_hud_hidecountdown.value)
+			return;
 
 		if (leveltime >= starttime-(2*TICRATE)) // 2
 			pnum++;
@@ -5231,7 +5237,7 @@ static void K_drawKartStartCountdown(void)
 		if (r_splitscreen) // splitscreen
 			pnum += 10;
 
-		V_DrawScaledPatch(STCD_X - (SHORT(kp_startcountdown[pnum]->width)/2), STCD_Y - (SHORT(kp_startcountdown[pnum]->height)/2), V_SPLITSCREEN, kp_startcountdown[pnum]);
+		V_DrawScaledPatch(STCD_X - (SHORT(kp_startcountdown[pnum]->width)/2), STCD_Y - (SHORT(kp_startcountdown[pnum]->height)/2), V_SPLITSCREEN|V_HUDTRANS, kp_startcountdown[pnum]);
 	}
 }
 
@@ -5643,7 +5649,7 @@ void K_drawKartFreePlay(void)
 		FRACUNIT,
 		FRACUNIT,
 		FRACUNIT,
-		V_SNAPTOBOTTOM|h_snap|V_SPLITSCREEN,
+		V_SNAPTOBOTTOM|h_snap|V_SPLITSCREEN|V_HUDTRANS,
 		NULL,
 		KART_FONT,
 		"FREE PLAY"
@@ -6470,7 +6476,7 @@ void K_drawKartHUD(void)
 			K_drawKartFinish(true);
 		else if (!(gametyperules & GTR_CIRCUIT))
 			;
-		else if (stplyr->karthud[khud_lapanimation] && !r_splitscreen)
+		else if (stplyr->karthud[khud_lapanimation] && !r_splitscreen && !cv_hud_hidelapemblem.value)
 			K_drawLapStartAnim();
 	}
 

--- a/src/k_profiles.cpp
+++ b/src/k_profiles.cpp
@@ -570,7 +570,13 @@ static void PR_ApplyProfile_Settings(profile_t *p, UINT8 playernum)
 	CV_StealthSetValue(&cv_litesteer[playernum], p->litesteer);
 	CV_StealthSetValue(&cv_autoring[playernum], p->autoring);
 	CV_StealthSetValue(&cv_rumble[playernum], p->rumble);
-	CV_StealthSetValue(&cv_fov[playernum], p->fov);
+
+	/**
+	 * RadioRacers - FOV CVAR INFO
+	 * 
+	 * Check cvars.cpp for information.
+	 */
+	// CV_StealthSetValue(&cv_fov[playernum], p->fov);
 
 	// set controls...
 	G_ApplyControlScheme(playernum, p->controls);

--- a/src/menus/options-1.c
+++ b/src/menus/options-1.c
@@ -18,6 +18,8 @@
 #include "../k_follower.h"
 #include "../s_sound.h"
 
+#include "../radioracers/rr_menu.h"
+
 // options menu --  see mopt_e
 menuitem_t OPTIONS_Main[] =
 {
@@ -47,6 +49,9 @@ menuitem_t OPTIONS_Main[] =
 	{IT_STRING | IT_CALL, "Tricks & Secrets", "Those who bother reading a game manual always get the edge over those who don't!",
 		NULL, {.routine = M_Manual}, 0, 0},
 #endif
+
+	// RadioRacers is too long :rolling_eyes:
+	{IT_STRING | IT_SUBMENU, "RADIO! Options", "Options controlling any RadioRacers changes.", NULL, {.submenu = &OPTIONS_RadioRacersMenuDef}, 0, 0},
 };
 
 // For options menu, the 'extra1' field will determine the background colour to use for... the background! (What a concept!)

--- a/src/menus/options-hud-1.c
+++ b/src/menus/options-hud-1.c
@@ -13,11 +13,22 @@
 #include "../r_main.h"	// cv_showhud
 #include "../v_video.h" // cv_constextsize
 
+#include "../radioracers/rr_menu.h" // RadioRacers
+
 menuitem_t OPTIONS_HUD[] =
 {
 
 	{IT_STRING | IT_CVAR, "Show HUD (F3)", "Toggles the Heads-Up display. Great for taking screenshots!",
 		NULL, {.cvar = &cv_showhud}, 0, 0},
+
+	{IT_SPACE | IT_NOTHING, NULL,  NULL,
+		NULL, {NULL}, 0, 0},
+
+	{IT_STRING | IT_CVAR | IT_CV_SLIDER, "HUD Translucency", "Self-explanatory. What are you, stupid?",
+		NULL, {.cvar = &cv_translucenthud}, 0, 0},
+
+	{IT_STRING | IT_SUBMENU, "RadioRacers HUD...", "Extended visual options for the HUD.",
+		NULL, {.submenu = &OPTIONS_RadioRacersHudDef}, 0, 0},
 
 	{IT_SPACE | IT_NOTHING, NULL,  NULL,
 		NULL, {NULL}, 0, 0},

--- a/src/menus/options-hud-1.c
+++ b/src/menus/options-hud-1.c
@@ -18,17 +18,17 @@
 menuitem_t OPTIONS_HUD[] =
 {
 
-	{IT_STRING | IT_CVAR, "Show HUD (F3)", "Toggles the Heads-Up display. Great for taking screenshots!",
-		NULL, {.cvar = &cv_showhud}, 0, 0},
-
+	{IT_STRING | IT_SUBMENU, "RadioRacers HUD Options...", "Extended visual options for the HUD.",
+		NULL, {.submenu = &OPTIONS_RadioRacersHudDef}, 0, 0},
+	
 	{IT_SPACE | IT_NOTHING, NULL,  NULL,
 		NULL, {NULL}, 0, 0},
 
 	{IT_STRING | IT_CVAR | IT_CV_SLIDER, "HUD Translucency", "Self-explanatory. What are you, stupid?",
 		NULL, {.cvar = &cv_translucenthud}, 0, 0},
 
-	{IT_STRING | IT_SUBMENU, "RadioRacers HUD...", "Extended visual options for the HUD.",
-		NULL, {.submenu = &OPTIONS_RadioRacersHudDef}, 0, 0},
+	{IT_STRING | IT_CVAR, "Show HUD (F3)", "Toggles the Heads-Up display. Great for taking screenshots!",
+		NULL, {.cvar = &cv_showhud}, 0, 0},
 
 	{IT_SPACE | IT_NOTHING, NULL,  NULL,
 		NULL, {NULL}, 0, 0},

--- a/src/menus/options-profiles-edit-1.c
+++ b/src/menus/options-profiles-edit-1.c
@@ -106,13 +106,20 @@ static void M_ProfileEditApply(void)
 	// Don't apply the profile itself as that would lead to issues mid-game.
 	if (belongsto > -1 && belongsto < MAXSPLITSCREENPLAYERS)
 	{
-		extern consvar_t cv_fov[MAXSPLITSCREENPLAYERS];
+		// extern consvar_t cv_fov[MAXSPLITSCREENPLAYERS];
 		CV_SetValue(&cv_kickstartaccel[belongsto], cv_dummyprofilekickstart.value);
 		CV_SetValue(&cv_autoroulette[belongsto], cv_dummyprofileautoroulette.value);
 		CV_SetValue(&cv_litesteer[belongsto], cv_dummyprofilelitesteer.value);
 		CV_SetValue(&cv_autoring[belongsto], cv_dummyprofileautoring.value);
 		CV_SetValue(&cv_rumble[belongsto], cv_dummyprofilerumble.value);
-		CV_SetValue(&cv_fov[belongsto], cv_dummyprofilefov.value);
+		
+
+		/**
+		 * RadioRacers - FOV CVAR INFO
+		 * 
+		 * Check cvars.cpp for information.
+		 */
+		// CV_SetValue(&cv_fov[belongsto], cv_dummyprofilefov.value);
 	}
 
 	// Reapply player 1's real profile.

--- a/src/menus/options-video-1.c
+++ b/src/menus/options-video-1.c
@@ -12,6 +12,7 @@
 #include "../k_menu.h"
 #include "../v_video.h" // cv_globalgamma
 #include "../r_fps.h" // fps cvars
+#include "../r_main.h"
 
 // options menu
 menuitem_t OPTIONS_Video[] =
@@ -36,6 +37,17 @@ menuitem_t OPTIONS_Video[] =
 
 	{IT_STRING | IT_CVAR, "Screen Effect", "Uses a special effect when displaying the game.",
 		NULL, {.cvar = &cv_scr_effect}, 0, 0},
+
+	/**
+	 * RadioRacers - FOV CVAR INFO
+	 * 
+	 * Pause Button -> Options -> Video Options -> Field of View
+	 * compared to
+	 * Pause Button -> Options -> Profile Setup -> Scroll to Profile -> Accessibility -> Field of View ....
+	 * 
+	 */
+	{IT_STRING | IT_CVAR, "Field of View", "Tweak the FOV for the first player (i.e. you).",
+		NULL, {.cvar = &cv_fov[0]}, 0, 0},
 
 	{IT_NOTHING|IT_SPACE, NULL, NULL,
 		NULL, {NULL}, 0, 0},

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -138,6 +138,7 @@ extern consvar_t cv_drawpickups;
 extern consvar_t cv_debugfinishline;
 extern consvar_t cv_drawinput;
 
+extern consvar_t cv_translucenthud;
 // debugging
 
 typedef enum {

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -138,7 +138,6 @@ extern consvar_t cv_drawpickups;
 extern consvar_t cv_debugfinishline;
 extern consvar_t cv_drawinput;
 
-extern consvar_t cv_translucenthud;
 // debugging
 
 typedef enum {

--- a/src/radioracers/CMakeLists.txt
+++ b/src/radioracers/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(netgame)
 add_subdirectory(gameplay)
+add_subdirectory(menus)

--- a/src/radioracers/gameplay/rr_controllerrumble.c
+++ b/src/radioracers/gameplay/rr_controllerrumble.c
@@ -85,11 +85,17 @@ uint16_t RR_GetRumbleStrength(const rumbleevent_e event)
 
 boolean RR_RumbleJustBumpedWall(const player_t *player)
 {
+    if (!cv_rr_rumble_wall_bump.value)
+        return false;
+    
     return (player->mo->eflags & MFE_JUSTBOUNCEDWALL);
 }
 
 boolean RR_RumbleIsSpindashingGently(const player_t *player)
 {
+    if (!cv_rr_rumble_spindash.value)
+        return false;
+    
     return (
             P_IsObjectOnGround(player->mo) &&
             player-> spindash && 
@@ -99,6 +105,9 @@ boolean RR_RumbleIsSpindashingGently(const player_t *player)
 
 boolean RR_RumbleIsSpindashingViolently(const player_t *player)
 {
+    if (!cv_rr_rumble_spindash.value)
+        return false;
+
     return (
             P_IsObjectOnGround(player->mo) &&
             player-> spindash && 
@@ -108,6 +117,8 @@ boolean RR_RumbleIsSpindashingViolently(const player_t *player)
 
 boolean RR_RumbleRingCollected(const player_t *player)
 {
+    if (!cv_rr_rumble_rings.value)
+        return false;
     return (
         player->mo && 
         player->rings < 20 &&
@@ -117,6 +128,8 @@ boolean RR_RumbleRingCollected(const player_t *player)
 
 boolean RR_RumbleChargingTailWhip(const player_t *player)
 {
+    if (!cv_rr_rumble_tailwhip.value)
+        return false;
     return (
         (player->mo) &&
         player->instaWhipCharge != 0 &&
@@ -126,6 +139,8 @@ boolean RR_RumbleChargingTailWhip(const player_t *player)
 
 boolean RR_RumbleOverchargingTailWhip(const player_t *player)
 {
+    if (!cv_rr_rumble_tailwhip.value)
+        return false;   
     return (
         (player->mo) &&
         player->instaWhipCharge >= INSTAWHIP_CHARGETIME
@@ -134,6 +149,9 @@ boolean RR_RumbleOverchargingTailWhip(const player_t *player)
 
 boolean RR_RumbleJustDrifted(const player_t *player)
 {
+    if (!cv_rr_rumble_drift.value)
+        return false;
+    
     // Charlie, Charlie! Have I told you how much I LOVE repeated code?!
     const INT32 dsone = K_GetKartDriftSparkValueForStage(player, 1);
     const INT32 dstwo = K_GetKartDriftSparkValueForStage(player, 2);
@@ -154,7 +172,10 @@ boolean RR_RumbleJustDrifted(const player_t *player)
 
 boolean RR_RumbleRingConsumed(const player_t *player)
 {
-    ticcmd_t *cmd = &player->cmd;
+    if (!cv_rr_rumble_rings.value)
+        return false;
+    
+    const ticcmd_t *cmd = &player->cmd;
     return (
         player->mo &&
         (
@@ -170,12 +191,13 @@ boolean RR_RumbleRingConsumed(const player_t *player)
 /**
  * These checks are kind of hacky. 
  * But I want the rumble to happen the FRAME that the ringboost timer has started.
- * That way, the player gets feedback immediately and knows when to start adjusting lines
- * and the sort.
+ * That way, the player gets feedback immediately and knows when to start adjusting lines and the sort.
  */
 
 boolean RR_RumbleJustFastFallBounced(const player_t *player)
 {
+    if (!cv_rr_rumble_fastfall_bounce.value)
+        return false;
     return (
         (player-> mo) &&
         player->fastfall !=0 &&
@@ -186,6 +208,8 @@ boolean RR_RumbleJustFastFallBounced(const player_t *player)
 
 boolean RR_RumbleJustWaveDashed(const player_t *player)
 {
+    if (!cv_rr_rumble_wavedash.value)
+        return false;
     return (
         (player->mo) &&
         P_IsObjectOnGround(player->mo) &&

--- a/src/radioracers/menus/CMakeLists.txt
+++ b/src/radioracers/menus/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(SRB2SDL2 PRIVATE
+    rr_menus.c
+)

--- a/src/radioracers/menus/rr_menus.c
+++ b/src/radioracers/menus/rr_menus.c
@@ -14,16 +14,48 @@
 #include "../../d_main.h"
 #include "../../v_video.h"
 
+// Main
+menuitem_t OPTIONS_RadioRacersMenu[] =
+{
+
+	{IT_HEADER, "Controller Rumble", NULL,
+		NULL, {NULL}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Extended Controller Rumbles", "Toggle the extended controller rumble events.",
+		NULL, {.cvar = &cv_morerumbleevents}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Rings", "Toggle controller rumble when you pickup and use rings.",
+		NULL, {.cvar = &cv_rr_rumble_rings}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Drift", "Toggle controller rumble when a new drift spark starts.",
+		NULL, {.cvar = &cv_rr_rumble_drift}, 0, 0},
+		
+	{IT_STRING | IT_CVAR, "Spindash", "Toggle controller rumble when spindashing.",
+		NULL, {.cvar = &cv_rr_rumble_spindash}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Wall Bump", "Toggle controller rumble when you bump into a wall.",
+		NULL, {.cvar = &cv_rr_rumble_wall_bump}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Fastfall Bounce", "Toggle controller rumble when you bounce after a fastfall.",
+		NULL, {.cvar = &cv_rr_rumble_fastfall_bounce}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Tailwhip", "Toggle controller rumble when you charge a tailwhip.",
+		NULL, {.cvar = &cv_rr_rumble_tailwhip}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Wavedash", "Toggle controller rumble when your wavedash boost starts.",
+		NULL, {.cvar = &cv_rr_rumble_wavedash}, 0, 0},
+};
+
 // HUD
 menuitem_t OPTIONS_RadioRacersHud[] =
-{
-	{IT_STRING | IT_CVAR, "Ring Counter Position", "Toggle between the Vanilla and Custom HUD positioning.",
-		NULL, {.cvar = &cv_ringsonplayer}, 0, 0},
-
-	{IT_SPACE | IT_NOTHING, NULL,  NULL,
+{	
+	{IT_HEADER, "Custom HUD Options", NULL,
 		NULL, {NULL}, 0, 0},
 	
-	{IT_HEADER, "Hide HUD Elements...", NULL,
+	{IT_STRING | IT_CVAR, "Ring Counter Position", "Toggle between the Vanilla and Custom HUD layout.",
+		NULL, {.cvar = &cv_ringsonplayer}, 0, 0},
+
+	{IT_HEADER, "Hide HUD Elements", NULL,
 		NULL, {NULL}, 0, 0},
     
 	{IT_STRING | IT_CVAR, "Hide Countdown", "Hide the countdown graphics at the beginning of a race.",
@@ -35,6 +67,7 @@ menuitem_t OPTIONS_RadioRacersHud[] =
 	{IT_STRING | IT_CVAR, "Hide Lap Emblem", "Hide the Lap Emblem when you begin a new lap.",
 		NULL, {.cvar = &cv_hud_hidelapemblem}, 0, 0}
 };
+
 
 menu_t OPTIONS_RadioRacersHudDef = {
 	sizeof (OPTIONS_RadioRacersHud) / sizeof (menuitem_t),
@@ -52,4 +85,33 @@ menu_t OPTIONS_RadioRacersHudDef = {
 	NULL,
 	NULL,
 	NULL,
+};
+
+void RumbleEvents_OnChange(void)
+{
+	if (con_startup) return;
+
+	UINT16 newstatus = (cv_morerumbleevents.value) ? IT_STRING | IT_CVAR : IT_GRAYEDOUT;
+
+	for (int i = 2; i < 9; i++) {
+		OPTIONS_RadioRacersMenu[i].status = newstatus;
+	}
+}
+
+menu_t OPTIONS_RadioRacersMenuDef = {
+	sizeof (OPTIONS_RadioRacersMenu) / sizeof (menuitem_t),
+	&OPTIONS_MainDef,
+	0,
+	OPTIONS_RadioRacersMenu,
+	48, 80,
+	SKINCOLOR_BANANA, 0,
+	MBF_DRAWBGWHILEPLAYING,
+	NULL,
+	2, 5,
+	M_DrawGenericOptions,
+	M_DrawOptionsCogs,
+	M_OptionsTick,
+	RumbleEvents_OnChange,
+	NULL,
+	NULL
 };

--- a/src/radioracers/menus/rr_menus.c
+++ b/src/radioracers/menus/rr_menus.c
@@ -1,0 +1,55 @@
+// RadioRacers
+//-----------------------------------------------------------------------------
+// Copyright (C) 2024 by $HOME
+//
+// This program is free software distributed under the
+// terms of the GNU General Public License, version 2.
+// See the 'LICENSE' file for more details.
+//-----------------------------------------------------------------------------
+/// \file radioracers/menu/rr_menus_hud.c
+
+#include "../rr_menu.h"
+#include "../rr_cvar.h"
+
+#include "../../d_main.h"
+#include "../../v_video.h"
+
+// HUD
+menuitem_t OPTIONS_RadioRacersHud[] =
+{
+	{IT_STRING | IT_CVAR, "Ring Counter Position", "Toggle between the Vanilla and Custom HUD positioning.",
+		NULL, {.cvar = &cv_ringsonplayer}, 0, 0},
+
+	{IT_SPACE | IT_NOTHING, NULL,  NULL,
+		NULL, {NULL}, 0, 0},
+	
+	{IT_HEADER, "Hide HUD Elements...", NULL,
+		NULL, {NULL}, 0, 0},
+    
+	{IT_STRING | IT_CVAR, "Hide Countdown", "Hide the countdown graphics at the beginning of a race.",
+		NULL, {.cvar = &cv_hud_hidecountdown}, 0, 0},
+        
+	{IT_STRING | IT_CVAR, "Hide POSITION!!!", "Hide the POSITION!!! graphics at the beginning of a race.",
+		NULL, {.cvar = &cv_hud_hideposition}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Hide Lap Emblem", "Hide the Lap Emblem when you begin a new lap.",
+		NULL, {.cvar = &cv_hud_hidelapemblem}, 0, 0}
+};
+
+menu_t OPTIONS_RadioRacersHudDef = {
+	sizeof (OPTIONS_RadioRacersHud) / sizeof (menuitem_t),
+	&OPTIONS_HUDDef,
+	0,
+	OPTIONS_RadioRacersHud,
+	48, 80,
+	SKINCOLOR_SUNSLAM, 0,
+	MBF_DRAWBGWHILEPLAYING,
+	NULL,
+	2, 5,
+	M_DrawGenericOptions,
+	M_DrawOptionsCogs,
+	M_OptionsTick,
+	NULL,
+	NULL,
+	NULL,
+};

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -26,6 +26,11 @@ extern consvar_t cv_votesnitch;         // Vote Snitch
 extern consvar_t cv_morerumbleevents;   // Extra gameplay events considered for controller rumble
 extern consvar_t cv_ringsonplayer;      // Rings drawn on player
 
+// HUD
+extern consvar_t cv_hud_hidecountdown; // Hide the bigass letters at the start of the race
+extern consvar_t cv_hud_hideposition;  // Hide the bigass position bulbs at the start of the race
+extern consvar_t cv_hud_hidelapemblem; // Hide the bigass lap emblem when you start a new lap
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -23,14 +23,25 @@ extern "C" {
 
 // Player (Clientside)
 extern consvar_t cv_votesnitch;         // Vote Snitch
-extern consvar_t cv_morerumbleevents;   // Extra gameplay events considered for controller rumble
 extern consvar_t cv_ringsonplayer;      // Rings drawn on player
 
+// Controller Rumble Toggles
+extern consvar_t cv_morerumbleevents;           // Extra gameplay events considered for controller rumble
+extern consvar_t cv_rr_rumble_wall_bump;        // Wall Bump
+extern consvar_t cv_rr_rumble_fastfall_bounce;  // Fastfall Bounce
+extern consvar_t cv_rr_rumble_drift;            // Drift
+extern consvar_t cv_rr_rumble_spindash;         // Spindash
+extern consvar_t cv_rr_rumble_tailwhip;         // Tailwhip
+extern consvar_t cv_rr_rumble_rings;            // Rings
+extern consvar_t cv_rr_rumble_wavedash;         // Wavedash
+
 // HUD
+extern consvar_t cv_translucenthud;    // Self-explanatory; controls HUD translucency 
 extern consvar_t cv_hud_hidecountdown; // Hide the bigass letters at the start of the race
 extern consvar_t cv_hud_hideposition;  // Hide the bigass position bulbs at the start of the race
 extern consvar_t cv_hud_hidelapemblem; // Hide the bigass lap emblem when you start a new lap
 
+void RumbleEvents_OnChange(void);
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/radioracers/rr_menu.h
+++ b/src/radioracers/rr_menu.h
@@ -26,6 +26,9 @@ extern "C" {
 extern menuitem_t OPTIONS_RadioRacersHud[];
 extern menu_t OPTIONS_RadioRacersHudDef;
 
+extern menuitem_t OPTIONS_RadioRacersMenu[];
+extern menu_t OPTIONS_RadioRacersMenuDef;
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/radioracers/rr_menu.h
+++ b/src/radioracers/rr_menu.h
@@ -1,0 +1,33 @@
+// RadioRacers
+//-----------------------------------------------------------------------------
+// Copyright (C) 2024 by $HOME
+//
+// This program is free software distributed under the
+// terms of the GNU General Public License, version 2.
+// See the 'LICENSE' file for more details.
+//-----------------------------------------------------------------------------
+/// \file radioracers/rr_menu.h
+/// \brief RadioRacers Menu Options
+
+#ifndef __RR_MENU__
+#define __RR_MENU__
+
+#include "../k_menu.h"
+#include "../m_cond.h"
+#include "../command.h"
+#include "../console.h"
+
+#include "rr_cvar.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern menuitem_t OPTIONS_RadioRacersHud[];
+extern menu_t OPTIONS_RadioRacersHudDef;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1580,7 +1580,12 @@ void ST_Drawer(void)
 			}
 		}
 
-		st_translucency = FixedMul(10, maxFade);
+		if (maxFade == FRACUNIT)
+			st_translucency = cv_translucenthud.value;
+		else
+			st_translucency = FixedMul(cv_translucenthud.value, maxFade);
+
+		st_translucency = min(max((st_translucency), 0), 10);
 	}
 
 	// Check for a valid level title

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -56,6 +56,8 @@
 #include "k_dialogue.h"
 #include "m_easing.h"
 
+#include "radioracers/rr_cvar.h"
+
 UINT16 objectsdrawn = 0;
 
 //

--- a/src/v_video.cpp
+++ b/src/v_video.cpp
@@ -751,15 +751,15 @@ static inline UINT8 transmappedpdraw(const UINT8 *dest, const UINT8 *source, fix
 
 UINT32 V_GetHUDTranslucency(INT32 scrn)
 {
-	if (scrn & V_SLIDEIN)
-	{
-		return 10;
-	}
+	// if (scrn & V_SLIDEIN)
+	// {
+	// 	return cv_translucenthud.value;
+	// }
 
-	if (scrn & V_SPLITSCREEN)
-	{
-		return FixedMul(10, st_fadein);
-	}
+	// if (scrn & V_SPLITSCREEN)
+	// {
+	// 	return FixedMul(cv_translucenthud.value, st_fadein);
+	// }
 
 	return st_translucency;
 }


### PR DESCRIPTION
```
+ HUD Translucency (!!!)
+ Controller Rumble Events CVARs (Wall Bump, Rings, Drift, etc)
+ Accompanying menu options for each bespoke CVAR made so far
+ Menu option for FOV in Video Options (***)
```
<sub>***The only change made here is making any profile changes to the FOV **not** overwrite the actual FOV cvar. In the future, I could/should just change the max FOV value allowed between per profile. But for now, this suffices for my personal needs.</sub>


![image](https://github.com/user-attachments/assets/ae0470f9-855f-46ac-a140-c9445d3accc0)

### RadioRacers HUD Options:
![RadioRacers HUD Options submenu](https://github.com/user-attachments/assets/0514276b-8672-47ad-8d61-7c8f64723bfc)

### Radio(Racers) Options:
![image](https://github.com/user-attachments/assets/a1d707ae-014a-4067-a250-9806414565d7)
![image](https://github.com/user-attachments/assets/517a0b77-478d-4e08-9b17-929743466d13)

