### PR TITLE
HUD tweaks - toggle HUD elements

### DIFF
--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -500,8 +500,8 @@ consvar_t stereoreverse = Player("stereoreverse", "Off").on_off();
  */
 // Backport of accessibility option from SRB2Kart.
 consvar_t cv_translucenthud = Player("translucenthud", "10").min_max(0, 10);
-
-consvar_t cv_driftsparkrate_size = Player("driftsparkpulsesize", "2.95").floating_point().min_max(0, 30*FRACUNIT).save();
+consvar_t cv_toggle_nametags = Player("nametags", "On").on_off();
+consvar_t cv_driftsparkrate_size = Player("driftsparkpulsesize", "2.95").floating_point().min_max(1, 30*FRACUNIT).step_amount(FRACUNIT).save();
 // Vote Snitch
 consvar_t cv_votesnitch = Player("votesnitch", "On").on_off();
 
@@ -615,6 +615,7 @@ consvar_t cv_toggle_laps_race = Player("racelapstoggle", "Default").values({
 	{1, "Minimal"}
 });
 
+consvar_t cv_toggle_position_number = Player("positionnumbertoggle", "On").on_off();
 consvar_t cv_toggle_race_minimap = Player("raceminimaptoggle", "On").on_off();
 consvar_t cv_toggle_trick_cool = Player("tricktexttoggle", "On").on_off();
 consvar_t cv_toggle_race_standings = Player("racestandingstoggle", "On").on_off();
@@ -1239,14 +1240,14 @@ consvar_t cv_autoring[MAXSPLITSCREENPLAYERS] = {
 };
 
 consvar_t cv_cam_dist[MAXSPLITSCREENPLAYERS] = {
-	Player("cam_dist", "190").floating_point(),
+	Player("cam_dist", "190").floating_point().min_max(190, 300*FRACUNIT).step_amount(FRACUNIT),
 	Player("cam2_dist", "190").floating_point(),
 	Player("cam3_dist", "190").floating_point(),
 	Player("cam4_dist", "190").floating_point(),
 };
 
 consvar_t cv_cam_height[MAXSPLITSCREENPLAYERS] = {
-	Player("cam_height", "95").floating_point(),
+	Player("cam_height", "95").floating_point().min_max(95, 300*FRACUNIT).step_amount(FRACUNIT),
 	Player("cam2_height", "95").floating_point(),
 	Player("cam3_height", "95").floating_point(),
 	Player("cam4_height", "95").floating_point(),
@@ -1326,7 +1327,7 @@ consvar_t cv_followercolor[MAXSPLITSCREENPLAYERS] = {
 
 void Fov_OnChange(void);
 consvar_t cv_fov[MAXSPLITSCREENPLAYERS] = {
-	Player("fov", "100").floating_point().min_max(60*FRACUNIT, 179*FRACUNIT).onchange(Fov_OnChange).dont_save(),
+	Player("fov", "100").floating_point().min_max(60*FRACUNIT, 179*FRACUNIT).step_amount(FRACUNIT).onchange(Fov_OnChange).dont_save(),
 	Player("fov2", "100").floating_point().min_max(60*FRACUNIT, 179*FRACUNIT).onchange(Fov_OnChange).dont_save(),
 	Player("fov3", "100").floating_point().min_max(60*FRACUNIT, 179*FRACUNIT).onchange(Fov_OnChange).dont_save(),
 	Player("fov4", "100").floating_point().min_max(60*FRACUNIT, 179*FRACUNIT).onchange(Fov_OnChange).dont_save(),

--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -501,6 +501,7 @@ consvar_t stereoreverse = Player("stereoreverse", "Off").on_off();
 // Backport of accessibility option from SRB2Kart.
 consvar_t cv_translucenthud = Player("translucenthud", "10").min_max(0, 10);
 
+consvar_t cv_driftsparkrate_size = Player("driftsparkpulsesize", "2.95").floating_point().min_max(0, 30*FRACUNIT).save();
 // Vote Snitch
 consvar_t cv_votesnitch = Player("votesnitch", "On").on_off();
 
@@ -524,7 +525,7 @@ consvar_t cv_rr_rumble_spheres = Player("rr_rumble_spheres", "On").on_off();
 consvar_t cv_rr_rumble_wavedash = Player("rr_rumble_wavedash", "On").on_off();
 
 // Rings drawn on player (akin to driftgauge)
-consvar_t cv_ringsonplayer = Player("ringsonplayer", "Vanilla").values({
+consvar_t cv_ringsonplayer = Player("ringsonplayer", "Custom").values({
 	{0, "Vanilla"}, 
 	{1, "Custom"}
 });
@@ -532,13 +533,13 @@ consvar_t cv_ringsonplayer = Player("ringsonplayer", "Vanilla").values({
 // -- Battle
 
 // Blue Sphere meter drawn on player
-consvar_t cv_spheremeteronplayer = Player("spheremeteronplayer", "Vanilla").values({
+consvar_t cv_spheremeteronplayer = Player("spheremeteronplayer", "Custom").values({
 	{0, "Vanilla"}, 
 	{1, "Custom"}
 });
 
 // Alterate Emerald display HUD
-consvar_t cv_customemeraldhud = Player("customemeraldhud", "Vanilla").values({
+consvar_t cv_customemeraldhud = Player("customemeraldhud", "Full").values({
 	{0, "Vanilla"}, 
 	{1, "Minimal"},
 	{2, "Full"}
@@ -554,8 +555,10 @@ consvar_t cv_battle_toggle_ufo_timer_on_minimap = Player("bttl_ufo_timer_on_mini
 // Toggle tracking players in the HUD
 consvar_t cv_targetrackplayers = Player("targetrackplayers", "Yes").yes_no();
 
+// -- Race
+
 // Item/Ringbox Roulette drawn on player
-consvar_t cv_rouletteonplayer = Player("rouletteonplayer", "Vanilla").values({
+consvar_t cv_rouletteonplayer = Player("rouletteonplayer", "Custom").values({
 	{0, "Vanilla"}, 
 	{1, "Custom"}
 }).onchange(Roulette_OnChange);
@@ -586,11 +589,11 @@ consvar_t cv_ringbox_roulette_player_position = Player("ringbox_roulette_player_
 consvar_t cv_item_roulette_player_position = Player("item_roulette_player_position", "Left").values(itemboxposition_cons_t);
 
 // Hide the giant big ass letters at the start of the race
-consvar_t cv_hud_hidecountdown = Player("hidecountdown", "No").yes_no();
+consvar_t cv_hud_hidecountdown = Player("hidecountdown", "On").on_off();
 // Hide the bigass position bulbs at the start of the race
-consvar_t cv_hud_hideposition = Player("hideposition", "No").yes_no();
+consvar_t cv_hud_hideposition = Player("hideposition", "On").on_off();
 // Hide the bigass lap emblem when you start a new lap
-consvar_t cv_hud_hidelapemblem = Player("hidelapemblem", "No").yes_no();
+consvar_t cv_hud_hidelapemblem = Player("hidelapemblem", "On").on_off();
 // Draw high-res portraits in the minirankings
 consvar_t cv_hud_usehighresportraits = Player("usehighresportraits", "Yes").yes_no();
 // Restore SRB2Kart behaviour when viewing in-game rankings (i.e. having to hold the button)
@@ -600,6 +603,23 @@ consvar_t cv_inputdisplaytoggle = Player("inputdisplaytoggle", "Digital").values
 	{'2', "Digital"}, 
 	{'4', "Analog"}
 });
+
+consvar_t cv_toggle_timestamp_race = Player("racetimestamptoggle", "Default").values({
+	{0, "Default"}, 
+	{1, "Minimal"},
+	{2, "Off"}
+});
+
+consvar_t cv_toggle_laps_race = Player("racelapstoggle", "Default").values({
+	{0, "Default"}, 
+	{1, "Minimal"}
+});
+
+consvar_t cv_toggle_race_minimap = Player("raceminimaptoggle", "On").on_off();
+consvar_t cv_toggle_trick_cool = Player("tricktexttoggle", "On").on_off();
+consvar_t cv_toggle_race_standings = Player("racestandingstoggle", "On").on_off();
+consvar_t cv_toggle_rings_excess = Player("showringsoverflow", "On").on_off();
+
 // Chat emotes
 consvar_t cv_chat_emotes = Player("chat_emotes", "On").on_off().onchange(RR_ChatEmotes_OnChange);
 consvar_t cv_chat_emotes_animated = Player("chat_emotes_animate", "On").on_off();

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -6695,7 +6695,7 @@ void K_drawKartHUD(void)
 				K_drawKartPlayerCheck();
 
 		// nametags
-		if (LUA_HudEnabled(hud_names) && cv_drawpickups.value)
+		if (LUA_HudEnabled(hud_names) && cv_drawpickups.value && (cv_toggle_nametags.value && !(gametyperules & GTR_POINTLIMIT)))
 			K_drawKartNameTags();
 
 		// Draw WANTED status
@@ -6911,7 +6911,7 @@ void K_drawKartHUD(void)
 						}
 					}
 				}
-				else if (!islonesome && !K_Cooperative())
+				else if (!islonesome && !K_Cooperative() && cv_toggle_position_number.value)
 					K_DrawKartPositionNum(stplyr->position);
 			}
 

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -1670,6 +1670,30 @@ static void K_drawKartItem(void)
 	auto draw_item = [&](fixed_t y, int i)
 	{
 		const UINT8 *colormap = (localcolor[i] ? R_GetTranslationColormap(colormode[i], localcolor[i], GTC_CACHE) : NULL);
+		// INT32 stupidflags = baseVideoFlags|fflags;
+		// if (i == 0 || i == 2) {
+
+		// 	INT32 offset = rouletteOffset / FRACUNIT;
+		// 	if (i == 0) {
+		// 		if (offset > 0) {
+		// 			if (offset > 9)
+		// 				offset = 9;
+		// 			transnum_t alpha = static_cast<transnum_t>(offset);
+		// 			stupidflags = (alpha << V_ALPHASHIFT);
+		// 		}
+		// 	} else {
+		// 		if (offset < 0) {
+		// 			INT32 absoffset = abs(offset);
+		// 			if (absoffset < 1)
+		// 				absoffset = 1;
+		// 			if (absoffset > 8)
+		// 				absoffset = 8;
+					
+		// 			CONS_Printf("offset %d / calc offset %d\n", absoffset, absoffset);
+		// 			stupidflags = (static_cast<transnum_t>(absoffset) << V_ALPHASHIFT);
+		// 		}
+		// 	}
+		// }
 		V_DrawFixedPatch(
 			fx<<FRACBITS, (fy<<FRACBITS) + rouletteOffset + y,
 			baseHudScale, baseVideoFlags|fflags,
@@ -2915,10 +2939,16 @@ static boolean K_drawKartPositionFaces(void)
 	if (!LUA_HudEnabled(hud_minirankings))
 		return false;	// Don't proceed but still return true for free play above if HUD is disabled.
 
+	boolean showstandings = cv_toggle_race_standings.value;
+	if (!showstandings && (gametyperules & GTR_POINTLIMIT)) {
+		showstandings = true;
+	}
+	
 	switch (r_splitscreen)
 	{
 	case 0:
-		state.draw_1p();
+		if (showstandings)
+			state.draw_1p();
 		break;
 
 	case 1:
@@ -3508,6 +3538,12 @@ static void K_drawRingCounter(boolean gametypeinfoshown)
 			using srb2::Draw;
 			Draw row = Draw(RINGC_X+23+3, fy-4).flags(ringcounterflags).font(Draw::Font::kThinTimer).colormap(ringmap);
 			row.text("{:02}", abs(stplyr->hudrings));
+
+			if (cv_toggle_rings_excess.value && stplyr->superring > 1 && abs(stplyr->hudrings) >= 19) {
+				// Draw excess rings (skypegiggle)
+				row.font(Draw::Font::kPing).x(12).y(4).colormap(R_GetTranslationColormap(TC_RAINBOW, SKINCOLOR_MINT, GTC_CACHE)).text("+");
+				row.font(Draw::Font::kThinTimer).x(18).colormap(R_GetTranslationColormap(TC_RAINBOW, SKINCOLOR_MINT, GTC_CACHE)).text("{:02}", abs(stplyr->superring));
+			}
 			// V_DrawMappedPatch(LAPS_X+23, fy, V_HUDTRANS|V_SLIDEIN|splitflags, fontv[TALLNUM_FONT].font[rn[0]], ringmap);
 			// V_DrawMappedPatch(LAPS_X+29, fy, V_HUDTRANS|V_SLIDEIN|splitflags, fontv[TALLNUM_FONT].font[rn[1]], ringmap);
 		}
@@ -5648,7 +5684,7 @@ static void K_drawKartStartCountdown(void)
 
 	if (leveltime >= introtime && leveltime < starttime-(3*TICRATE))
 	{
-		if (cv_hud_hideposition.value)
+		if (!cv_hud_hideposition.value)
 			return;
 		
 		if (numbulbs > 1)
@@ -6671,7 +6707,12 @@ void K_drawKartHUD(void)
 		}
 #endif
 
-		if (LUA_HudEnabled(hud_minimap))
+		boolean showminimap = cv_toggle_race_minimap.value;
+		// Show the minimap during battle, it's important information
+		if (!showminimap && (gametyperules & GTR_POINTLIMIT)) {
+			showminimap = true;
+		}
+		if (LUA_HudEnabled(hud_minimap) && showminimap)
 			K_drawKartMinimap();
 	}
 
@@ -6706,7 +6747,22 @@ void K_drawKartHUD(void)
 				}
 			}
 
-			K_drawKartTimestamp(realtime, TIME_X, TIME_Y + (ta ? 2 : 0), flags, 0);
+			if ((gametyperules & GTR_POINTLIMIT) || modeattacking) // Playing Battle or Time-Attacking
+			{
+				K_drawKartTimestamp(realtime, TIME_X, TIME_Y + (ta ? 2 : 0), flags, 0);
+			} else {
+				switch(cv_toggle_timestamp_race.value)
+				{
+					case 0:
+						K_drawKartTimestamp(realtime, TIME_X, TIME_Y + (ta ? 2 : 0), flags, 0);
+						break;
+					case 1:
+						RR_DrawKartMiniTimestamp(realtime, TIME_X, TIME_Y + (ta ? 2 : 0), flags, 0);
+						break;
+					case 2:
+						break;
+				}
+			}
 
 			if (modeattacking)
 			{
@@ -6865,7 +6921,19 @@ void K_drawKartHUD(void)
 				{
 					if (numlaps != 1)
 					{
-						K_drawKartLaps();
+						// RADIO
+						switch (cv_toggle_laps_race.value)
+						{
+							case 0:
+								K_drawKartLaps();
+								break;
+							case 1:
+								RR_DrawKartLapsMini();
+								break;
+							default:
+								K_drawKartLaps();
+								break;
+						}
 						gametypeinfoshown = true;
 					}
 				}
@@ -6945,12 +7013,12 @@ void K_drawKartHUD(void)
 			K_drawKartFinish(true);
 		else if (!(gametyperules & GTR_CIRCUIT))
 			;
-		else if (stplyr->karthud[khud_lapanimation] && !r_splitscreen && !cv_hud_hidelapemblem.value)
+		else if (stplyr->karthud[khud_lapanimation] && !r_splitscreen && cv_hud_hidelapemblem.value)
 			K_drawLapStartAnim();
 	}
 
 	// trick panel cool trick
-	if (stplyr->karthud[khud_trickcool])
+	if (stplyr->karthud[khud_trickcool] && cv_toggle_trick_cool.value)
 		K_drawTrickCool();
 
 	if ((freecam || stplyr->spectator) && LUA_HudEnabled(hud_textspectator))

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -5773,7 +5773,7 @@ static void K_SpawnDriftSparks(player_t *player)
 			if (player->driftcharge <= (dsfour)+(32*3))
 			{
 				// transition
-				P_SetScale(spark, (spark->destscale = spark->scale*3/2));
+				P_SetScale(spark, (spark->destscale = FixedMul(spark->scale, cv_driftsparkrate_size.value)));
 				S_StartSound(player->mo, sfx_cock);
 			}
 			else
@@ -5790,7 +5790,7 @@ static void K_SpawnDriftSparks(player_t *player)
 			if (player->driftcharge <= dsthree+(32*3))
 			{
 				// transition
-				P_SetScale(spark, (spark->destscale = spark->scale*3/2));
+				P_SetScale(spark, (spark->destscale = FixedMul(spark->scale, cv_driftsparkrate_size.value)));
 			}
 		}
 		else if (player->driftcharge >= dstwo)
@@ -5802,7 +5802,7 @@ static void K_SpawnDriftSparks(player_t *player)
 			if (player->driftcharge <= dstwo+(32*3))
 			{
 				// transition
-				P_SetScale(spark, (spark->destscale = spark->scale*3/2));
+				P_SetScale(spark, (spark->destscale = FixedMul(spark->scale, cv_driftsparkrate_size.value)));
 			}
 		}
 		else
@@ -5813,7 +5813,7 @@ static void K_SpawnDriftSparks(player_t *player)
 			if (player->driftcharge <= dsone+(32*3))
 			{
 				// transition
-				P_SetScale(spark, (spark->destscale = spark->scale*2));
+				P_SetScale(spark, (spark->destscale = FixedMul(spark->scale, cv_driftsparkrate_size.value)));
 			}
 		}
 

--- a/src/menus/options-video-1.c
+++ b/src/menus/options-video-1.c
@@ -46,6 +46,13 @@ menuitem_t OPTIONS_Video[] =
 	 * Pause Button -> Options -> Profile Setup -> Scroll to Profile -> Accessibility -> Field of View ....
 	 * 
 	 */
+
+	{IT_STRING | IT_CVAR, "Camera Height", "Tweak the camera HEIGHT for the first player (i.e. you).",
+		NULL, {.cvar = &cv_cam_height[0]}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Camera Distance", "Tweak the camera DISTANCE for the first player (i.e. you).",
+		NULL, {.cvar = &cv_cam_dist[0]}, 0, 0},
+	
 	{IT_STRING | IT_CVAR, "Field of View", "Tweak the FOV for the first player (i.e. you).",
 		NULL, {.cvar = &cv_fov[0]}, 0, 0},
 

--- a/src/radioracers/hud/CMakeLists.txt
+++ b/src/radioracers/hud/CMakeLists.txt
@@ -3,4 +3,5 @@ target_sources(SRB2SDL2 PRIVATE
 	rr_tally.cpp
 	rr_setup.cpp
 	rr_emotes.cpp
+	rr_timer.cpp
 )

--- a/src/radioracers/hud/rr_hud.cpp
+++ b/src/radioracers/hud/rr_hud.cpp
@@ -764,6 +764,38 @@ void RR_drawRidersFinishTicker(void)
     }
 }
 
+/** 
+ * Draw mini laps
+ */
+void RR_DrawKartLapsMini(void)
+{
+    if (r_splitscreen)
+        return;
+    
+    const INT32 MINI_LAPS_Y = LAPS_Y + 5;
+    const INT32 splitflags = V_HUDTRANS|V_SLIDEIN|V_SNAPTOBOTTOM|V_SNAPTOLEFT;
+    using srb2::Draw;
+
+    Draw(LAPS_X + 7, MINI_LAPS_Y)
+        .flags(splitflags)
+        .align(Draw::Align::kCenter)
+        .width(40)
+        .small_sticker();
+
+    V_DrawScaledPatch(
+        LAPS_X + 8, 
+        MINI_LAPS_Y - 2, 
+        splitflags, 
+        static_cast<patch_t *>(W_CachePatchName("K_SPTLAP", PU_HUDGFX))
+    );
+        
+    V_DrawThinTimerString(
+        LAPS_X+24, 
+        MINI_LAPS_Y - 4, 
+        splitflags, 
+        va("%d/%d", std::min(stplyr->laps, numlaps), numlaps)
+    );
+}
 /**
  * Empty the queue!
  */

--- a/src/radioracers/hud/rr_setup.cpp
+++ b/src/radioracers/hud/rr_setup.cpp
@@ -24,9 +24,37 @@
 #include "../../z_zone.h"
 #include "../../r_defs.h"
 #include "../../r_picformats.h"
+#include "../../deh_tables.h"
 
 static const char* EMOTE_FRAME_NAME = "FRAME";
 static const char* EMOTE_ATLAS_FRAME_NAME = "EMOATLAS";
+
+
+std::vector<std::string> OLD_RING_STATES = {
+    "S_RING_OLD",
+    "S_FASTRINGOLD1",
+    "S_FASTRINGOLD2",
+    "S_FASTRINGOLD3",
+    "S_FASTRINGOLD4",
+    "S_FASTRINGOLD5",
+    "S_FASTRINGOLD6",
+    "S_FASTRINGOLD7",
+    "S_FASTRINGOLD8",
+    "S_FASTRINGOLD9",
+    "S_FASTRINGOLD10",
+    "S_FASTRINGOLD11",
+    "S_FASTRINGOLD12",
+};
+/**
+ * freeslotting in lua converts the sprite name (e.g. "SPR_RING" -> "RING") into an integer.
+ * Each letter is an ASCII code (e.g. "R" = 82 = 0x82), and 
+ * the resulting integer is the 4 separate bytes (for each character) as one BIG number!
+ * Clever stuff.
+ * 
+ * So instead of JUST storing a string then converting it.. store the integer representation too.
+ */
+static const char* OLD_RING_SPRNAME = "RNGO";
+static const uint32_t OLD_RING_INTEGER = 0x524E474F;
 
 boolean found_radioracers = false;
 boolean found_radioracers_plus = false;
@@ -850,6 +878,59 @@ void RR_CleanupEmoteFrames(void) {
     emoteLastUpdate.clear();
 }
 
+// Add old ring sprite and state by freeslotting them
+static void AddOldRings(void)
+{
+    // snipping out the SPR and S_ freeslot branches from lib_freeslot
+
+    // freeslot the sprite name
+    int idx;
+    for (idx = SPR_FIRSTFREESLOT; idx <= SPR_LASTFREESLOT; idx++)
+    {
+        spritenum_t j = (spritenum_t)(idx);
+        if (used_spr[(j-SPR_FIRSTFREESLOT)/8] & (1<<(j%8)))
+        {
+            if (!sprnames[j][4] && memcmp(sprnames[j],OLD_RING_SPRNAME,4)==0)
+                sprnames[j][4] = static_cast<char>(OLD_RING_INTEGER);
+            continue; // Already allocated, next.
+        }
+        // Found a free slot!
+        CONS_Printf("RADIO: Sprite SPR_%s allocated.\n", OLD_RING_SPRNAME);
+        memcpy(sprnames[j],OLD_RING_SPRNAME,4);
+        sprnames[j][4] = '\0';
+        used_spr[(j-SPR_FIRSTFREESLOT)/8] |= 1<<(j%8); // Okay, this sprite slot has been named now.
+        break;
+    }
+    if (idx > SPR_LASTFREESLOT)
+        CONS_Alert(CONS_WARNING, "Ran out of free sprite slots!\n");
+
+    // and freeslot the state
+    // loop over state vector and assign all the state properties, the sprite name etc
+    // save the statenum_t (return S_FIRSTFREESLOT+i;)
+    // and then loop get the state by id states[ID] and set all the shit there
+    // check hw_main.c
+    int i;
+    int test = 0;
+    for (i = 0; i < NUMSTATEFREESLOTS; i++) {
+        statenum_t s = (statenum_t)(i);
+
+        if (!FREE_STATES[s]) {
+            CONS_Printf("RADIO: State S_%s allocated.\n","S_RING_OLD");
+            FREE_STATES[s] = static_cast<char*>(Z_Malloc(strlen("S_RING_OLD")+1, PU_STATIC, NULL));
+            strcpy(FREE_STATES[s],"S_RING_OLD");
+            CONS_Printf("idx %d\n", i);
+            test = i;
+            break;
+        }
+    }
+    if (i == NUMSTATEFREESLOTS)
+        CONS_Alert(CONS_WARNING, "Ran out of free State slots!\n");
+
+    // CONS_Printf("RADIO TEST: %s\n", FREE_STATES[test]);
+
+    // and then define the states manually
+}
+
 /** Initialize anything relating to RadioRacers */
 void RR_Init(void) {
     if (dedicated)
@@ -878,6 +959,9 @@ void RR_Init(void) {
             HU_UpdatePatch(&end_key[1], "EMENU_AB");
             radioracers_useendkey = true;
         }
+
+        // Ring style
+        // AddOldRings();
     }
 
     // Any emotes?

--- a/src/radioracers/hud/rr_timer.cpp
+++ b/src/radioracers/hud/rr_timer.cpp
@@ -1,0 +1,205 @@
+// RadioRacers
+//-----------------------------------------------------------------------------
+// Copyright (C) 2025 by $HOME
+//
+// This program is free software distributed under the
+// terms of the GNU General Public License, version 2.
+// See the 'LICENSE' file for more details.
+//-----------------------------------------------------------------------------
+/// \file radioracers/rr_timer.cpp
+
+#include <algorithm>
+
+#include "../rr_cvar.h"
+#include "../rr_video.h"
+#include "../rr_hud.h"
+
+#include "../../doomstat.h"
+#include "../../g_game.h"
+#include "../../k_hud.h"
+#include "../../p_local.h"
+#include "../../r_fps.h"
+#include "../../z_zone.h"
+#include "../../w_wad.h"
+#include "../../st_stuff.h"
+#include "../../v_draw.hpp"
+
+// This isn't exposed in k_hud.h, so just copying this here.
+tic_t player_timer(const player_t* player)
+{
+	if (player->realtime == UINT32_MAX)
+	{
+		return 0;
+	}
+
+	return K_TranslateTimer(player->realtime, 0, nullptr);
+}
+
+/** Unfortunately, this is tied to the original K_drawKartTimestamp function. So, just copy it here.*/
+static void DrawSPBAttack_Bar(void)
+{
+    if (modeattacking & ATTACKING_SPB && stplyr->SPBdistance > 0)
+	{
+		UINT8 *colormap = R_GetTranslationColormap(stplyr->skin, static_cast<skincolornum_t>(stplyr->skincolor), GTC_CACHE);
+		INT32 ybar = 180;
+		INT32 widthbar = 120, xbar = 160 - widthbar/2, currentx;
+		INT32 barflags = V_SNAPTOBOTTOM|V_SLIDEIN;
+		INT32 transflags = ((6)<<FF_TRANSSHIFT);
+
+		V_DrawScaledPatch(xbar, ybar - 2, barflags|transflags, 
+            static_cast<patch_t*>(W_CachePatchName("MINIPROG", PU_HUDGFX))
+        );
+
+		V_DrawMappedPatch(160 + widthbar/2 - 7, ybar - 7, barflags, faceprefix[stplyr->skin][FACE_MINIMAP], colormap);
+
+		// vibes-based math
+		currentx = (stplyr->SPBdistance/mapobjectscale - mobjinfo[MT_SPB].radius/FRACUNIT - mobjinfo[MT_PLAYER].radius/FRACUNIT) * 6;
+		if (currentx > 0)
+		{
+			currentx = sqrt(currentx);
+			if (currentx > widthbar)
+				currentx = widthbar;
+		}
+		else
+		{
+			currentx = 0;
+		}
+		V_DrawScaledPatch(160 + widthbar/2 - currentx - 5, ybar - 7, barflags, 
+            static_cast<patch_t*>(W_CachePatchName("SPBMMAP", PU_HUDGFX))
+        );
+	}
+}
+
+void RR_DrawKartMiniTimestamp(tic_t drawtime, INT32 TX, INT32 TY, INT32 splitflags, UINT8 mode)
+{
+    if (r_splitscreen)
+        return;
+    
+    // Mostly copying the logic from RR_DrawKartTimestamp, just tweaking it to accomodate the thin-timer font
+    TX += 80;
+
+    INT32 jitter = 0;
+    drawtime = K_TranslateTimer(drawtime, mode, &jitter);
+
+    using srb2::Draw;
+    Draw(TX-12, TY+7)
+        .flags(splitflags)
+        .align(Draw::Align::kCenter)
+        .width(65)
+        .small_sticker();
+
+    V_DrawScaledPatch(TX-10, TY+4, splitflags, static_cast<patch_t *>(W_CachePatchName("K_STTIMS", PU_HUDGFX)));
+
+    TX += 4;
+
+    if (drawtime == UINT32_MAX)
+        ;
+    else if (mode && !drawtime)
+    {
+        // apostrophe location     _'__ __
+        V_DrawThinTimerString(TX+12, TY+3, splitflags, va("'"));
+
+        // quotation mark location    _ __"__
+        V_DrawTimerString(TX+30, TY+3, splitflags, va("\""));
+    }
+    else
+    {
+        tic_t worktime = drawtime/(60*TICRATE);
+
+        if (worktime >= 100)
+        {
+            jitter = (drawtime & 1 ? 1 : -1);
+            worktime = 99;
+            drawtime = (100*(60*TICRATE))-1;
+        }
+
+        // minutes time      00 __ __
+        V_DrawThinTimerString(TX,    TY+3+jitter, splitflags, va("%d", worktime/10));
+        V_DrawThinTimerString(TX+6, TY+3-jitter, splitflags, va("%d", worktime%10));
+
+        // apostrophe location     _'__ __
+        V_DrawThinTimerString(TX+12, TY+3, splitflags, va("'"));
+
+        worktime = (drawtime/TICRATE % 60);
+
+        // seconds time       _ 00 __
+        V_DrawThinTimerString(TX+18, TY+3+jitter, splitflags, va("%d", worktime/10));
+        V_DrawThinTimerString(TX+24, TY+3-jitter, splitflags, va("%d", worktime%10));
+
+        // quotation mark location    _ __"__
+        V_DrawThinTimerString(TX+30, TY+3, splitflags, va("\""));
+
+        worktime = G_TicsToCentiseconds(drawtime);
+
+        // tics               _ __ 00
+        V_DrawThinTimerString(TX+36, TY+3+jitter, splitflags, va("%d", worktime/10));
+        V_DrawThinTimerString(TX+42, TY+3-jitter, splitflags, va("%d", worktime%10));
+    }
+
+    TX-= 84;
+    TX+= 33;
+
+    // Medal data!
+	if ((modeattacking || (mode == 1))
+    && !demo.playback)
+    {
+        INT32 workx = TX + 96, worky = TY+18;
+        UINT8 i = stickermedalinfo.visiblecount;
+
+        if (stickermedalinfo.targettext[0] != '\0')
+        {
+            if (!mode)
+            {
+                if (stickermedalinfo.jitter)
+                {
+                    jitter = stickermedalinfo.jitter+3;
+                    if (jitter & 2)
+                        workx += jitter/4;
+                    else
+                        workx -= jitter/4;
+                }
+
+                if (stickermedalinfo.norecord == true)
+                {
+                    splitflags = (splitflags &~ V_HUDTRANS)|V_HUDTRANSHALF;
+                }
+            }
+
+            workx -= K_drawKartMicroTime(stickermedalinfo.targettext, workx, worky, splitflags);
+        }
+
+        workx -= (((1 + i - stickermedalinfo.platinumcount)*6) - 1);
+
+        if (!mode)
+            splitflags = (splitflags &~ V_HUDTRANSHALF)|V_HUDTRANS;
+        while (i > 0)
+        {
+            i--;
+
+            if (gamedata->collected[(stickermedalinfo.emblems[i]-emblemlocations)])
+            {
+                V_DrawMappedPatch(workx, worky, splitflags,
+                    static_cast<patch_t*>(W_CachePatchName(M_GetEmblemPatch(stickermedalinfo.emblems[i], false), PU_CACHE)),
+                    R_GetTranslationColormap(TC_DEFAULT, M_GetEmblemColor(stickermedalinfo.emblems[i]), GTC_CACHE)
+                );
+
+                workx += 6;
+            }
+            else if (
+                stickermedalinfo.emblems[i]->type != ET_TIME
+                || stickermedalinfo.emblems[i]->tag != AUTOMEDAL_PLATINUM
+            )
+            {
+                V_DrawMappedPatch(workx, worky, splitflags,
+                    static_cast<patch_t*>(W_CachePatchName("NEEDIT", PU_CACHE)),
+                    NULL
+                );
+
+                workx += 6;
+            }
+        }
+    }
+
+    // SPB Attack
+    DrawSPBAttack_Bar();
+}

--- a/src/radioracers/menus/rr_menus.c
+++ b/src/radioracers/menus/rr_menus.c
@@ -15,6 +15,7 @@
 #include "../../d_main.h"
 #include "../../v_video.h"
 #include "../../k_kart.h"
+#include "../../r_main.h"
 
 // HUD Options - Race
 static menuitem_t OPTIONS_RadioRacersHudRace[] =
@@ -25,14 +26,17 @@ static menuitem_t OPTIONS_RadioRacersHudRace[] =
 	{IT_STRING | IT_CVAR, "Ring Counter Overflow", "Show/hide overflow text on RING COUNTER.",
 		NULL, {.cvar = &cv_toggle_rings_excess}, 0, 0},
 
-	{IT_SPACE | IT_NOTHING, NULL,  NULL,
-		NULL, {NULL}, 0, 0},
-
 	{IT_HEADER, "Toggle HUD Elements", NULL,
 		NULL, {NULL}, 0, 0},
 
 	{IT_STRING | IT_CVAR, "Timer", "Toggle the display style for the Timer.",
 		NULL, {.cvar = &cv_toggle_timestamp_race}, 0, 0},   
+		
+	{IT_STRING | IT_CVAR, "Nametags", "Toggle in-game nametags.",
+		NULL, {.cvar = &cv_toggle_nametags}, 0, 0},   
+		
+	{IT_STRING | IT_CVAR, "Position Number", "Toggle position number on the bottom-right.",
+		NULL, {.cvar = &cv_toggle_position_number}, 0, 0},   
 
 	{IT_STRING | IT_CVAR, "Laps", "Toggle the display style for the Laps.",
 		NULL, {.cvar = &cv_toggle_laps_race}, 0, 0}, 

--- a/src/radioracers/menus/rr_menus.c
+++ b/src/radioracers/menus/rr_menus.c
@@ -22,19 +22,37 @@ static menuitem_t OPTIONS_RadioRacersHudRace[] =
 	{IT_STRING | IT_CVAR, "Ring Counter Position", "Toggle the RING COUNTER's HUD position.",
 		NULL, {.cvar = &cv_ringsonplayer}, 0, 0},
 
+	{IT_STRING | IT_CVAR, "Ring Counter Overflow", "Show/hide overflow text on RING COUNTER.",
+		NULL, {.cvar = &cv_toggle_rings_excess}, 0, 0},
+
 	{IT_SPACE | IT_NOTHING, NULL,  NULL,
 		NULL, {NULL}, 0, 0},
 
-	{IT_HEADER, "Hide HUD Elements", NULL,
+	{IT_HEADER, "Toggle HUD Elements", NULL,
 		NULL, {NULL}, 0, 0},
 
-	{IT_STRING | IT_CVAR, "Countdown", "Hide the countdown graphics at the beginning of a race.",
+	{IT_STRING | IT_CVAR, "Timer", "Toggle the display style for the Timer.",
+		NULL, {.cvar = &cv_toggle_timestamp_race}, 0, 0},   
+
+	{IT_STRING | IT_CVAR, "Laps", "Toggle the display style for the Laps.",
+		NULL, {.cvar = &cv_toggle_laps_race}, 0, 0}, 
+
+	{IT_STRING | IT_CVAR, "Minimap", "Hide the minimap.",
+		NULL, {.cvar = &cv_toggle_race_minimap}, 0, 0},   
+
+	{IT_STRING | IT_CVAR, "Player Standings", "Show/hide the player standings.",
+		NULL, {.cvar = &cv_toggle_race_standings}, 0, 0},   
+
+	{IT_STRING | IT_CVAR, "Trick Text", "Show/hide the 'COOL' text when performing a trick.",
+		NULL, {.cvar = &cv_toggle_trick_cool}, 0, 0},   
+
+	{IT_STRING | IT_CVAR, "Countdown", "Show/hide the countdown graphics at the beginning of a race.",
 		NULL, {.cvar = &cv_hud_hidecountdown}, 0, 0},   
             
-	{IT_STRING | IT_CVAR, "POSITION!!!", "Hide the POSITION!!! graphics at the beginning of a race.",
+	{IT_STRING | IT_CVAR, "POSITION!!!", "Show/hide the POSITION!!! graphics at the beginning of a race.",
 		NULL, {.cvar = &cv_hud_hideposition}, 0, 0},
 
-	{IT_STRING | IT_CVAR, "Lap Emblem", "Hide the Lap Emblem when you begin a new lap.",
+	{IT_STRING | IT_CVAR, "Lap Emblem", "Show/hide the Lap Emblem when you begin a new lap.",
 		NULL, {.cvar = &cv_hud_hidelapemblem}, 0, 0}
 };
 
@@ -169,6 +187,9 @@ menu_t OPTIONS_RadioRacersHudDef = {
 // Gameplay
 static menuitem_t OPTIONS_RadioRacersGameplay[] =
 {			
+	{IT_STRING | IT_CVAR, "Drift Spark Pulse Size", "Tweak the scale of the drift spark whilst drifting.",
+		NULL, {.cvar = &cv_driftsparkrate_size}, 0, 0},
+
 	{IT_STRING | IT_CVAR, "Extended Controller Rumbles", "Toggle the extended controller rumble events.",
 		NULL, {.cvar = &cv_morerumbleevents}, 0, 0},
 
@@ -299,7 +320,7 @@ void RumbleEvents_OnChange(void)
 
 	UINT16 newstatus = (cv_morerumbleevents.value) ? IT_STRING | IT_CVAR : IT_GRAYEDOUT;
 
-	for (int i = 2; i < 10; i++) {
+	for (int i = 3; i < 11; i++) {
 		OPTIONS_RadioRacersGameplay[i].status = newstatus;
 	}
 

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -79,6 +79,8 @@ extern consvar_t cv_chat_emotes_button;             // Toggle the END key button
 extern consvar_t cv_chat_emotes_preview;            // Toggle emotes previewing in the chat input
 extern consvar_t cv_chat_emotes_sort;               // Toggle sorting function in the emote menu
 extern consvar_t cv_driftsparkrate_size; // Toggle spark rate pulse size when drifting (Thank you Callmore xxxxx)
+extern consvar_t cv_toggle_nametags; // Toggle nametags
+extern consvar_t cv_toggle_position_number; // Toggle position number
 extern consvar_t cv_toggle_rings_excess; // Toggle the green text showing ring count overflow
 extern consvar_t cv_toggle_timestamp_race; // Toggle the timestamp in the top right
 extern consvar_t cv_toggle_laps_race;       // Toggle the display style for the laps in the bottom left

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -78,6 +78,13 @@ extern consvar_t cv_chat_emotes_animated;           // Should emotes animate?
 extern consvar_t cv_chat_emotes_button;             // Toggle the END key button
 extern consvar_t cv_chat_emotes_preview;            // Toggle emotes previewing in the chat input
 extern consvar_t cv_chat_emotes_sort;               // Toggle sorting function in the emote menu
+extern consvar_t cv_driftsparkrate_size; // Toggle spark rate pulse size when drifting (Thank you Callmore xxxxx)
+extern consvar_t cv_toggle_rings_excess; // Toggle the green text showing ring count overflow
+extern consvar_t cv_toggle_timestamp_race; // Toggle the timestamp in the top right
+extern consvar_t cv_toggle_laps_race;       // Toggle the display style for the laps in the bottom left
+extern consvar_t cv_toggle_race_minimap;    // Toggle the minimap
+extern consvar_t cv_toggle_race_standings;    // Toggle the player standings
+extern consvar_t cv_toggle_trick_cool;    // Toggle the "COOL!" graphic when you do a successful trick
 
 // HUD -- Battle
 extern consvar_t cv_battle_toggle_emerald_on_minimap; 

--- a/src/radioracers/rr_hud.h
+++ b/src/radioracers/rr_hud.h
@@ -268,6 +268,7 @@ extern void RR_addPlayerToFinshTicker(player_t *player);
 extern void RR_drawRidersFinishTicker(void);
 extern void RR_ridersFinishTick(void);
 extern void RR_resetRidersFinishTicker(void);
+extern void RR_DrawKartLapsMini(void);
 
 typedef struct
 {
@@ -287,6 +288,11 @@ extern int hu_radio_tick;
 extern void RR_DoChatStuff(chat_box_parameters_t parameters);
 // Tally
 void RR_DrawGradeEmote(player_grade_info_t grade_info);
+
+/**
+ * Timer
+ */
+extern void RR_DrawKartMiniTimestamp(tic_t drawtime, INT32 TX, INT32 TY, INT32 splitflags, UINT8 mode);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/radioracers/rr_video.h
+++ b/src/radioracers/rr_video.h
@@ -15,6 +15,7 @@
 #include "../m_cond.h"
 #include "../command.h"
 #include "../console.h"
+#include "../v_video.h"
 
 #include "rr_cvar.h"
 #include "rr_controller.h"
@@ -100,6 +101,10 @@ extern "C" {
 
 #define EMOTE_PADDING 1
 #define GET_CHAT_EMOTE_SCALE(h, has_text) (((has_text) ? MAX_HEIGHT_WITH_TEXT : MAX_HEIGHT)/static_cast<float_t>(h))
+
+// Thin timer font isn't used anywhere
+#define V_DrawThinTimerString( x,y,option,string ) \
+	V__DrawDupxString (x,y,FRACUNIT,option,NULL,TINYTIMER_FONT,string)
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
+ New option - `Ring Counter Overflow`
Show the overflow of rings in your ring counter:
![ringracers_feature_hud-tweaks_r4LfhLeBU1](https://github.com/user-attachments/assets/ea4ab1a3-8b01-4a4d-8601-9154198de334)

Added more options to toggle in the HUD:

`Settings` ⟶ `Radio Options`  ⟶ `HUD` ⟶ `Race`:

![image](https://github.com/user-attachments/assets/f322b6b6-8e02-427a-a04d-dcefa9bce201)

| Setting| Description |
| -------- | ------- |
|Timer| Toggle the display style for the Timer.|
|Nametags| Toggle in-game nametags.|
|Position Number| Toggle position number on the bottom-right.|
|Laps| Toggle the display style for the Laps.|
|Minimap| Hide the minimap.|
|Player Standings| Show/hide the player standings.|
|Trick Text| Show/hide the 'COOL' text when performing a trick.|
|Countdown| Hide the countdown graphics at the beginning of a race.|

> Laps
- Use the default style or a smaller version of the laps graphic:
![image](https://github.com/user-attachments/assets/1f54d723-f8ff-45de-824b-0fad0813c7b2)

> Timer
- Use the default timer style, a smaller version, or turn it off completely.
![image](https://github.com/user-attachments/assets/12098461-a828-4017-bd1d-13d9fdfdb85e)


