### PR TITLE
Accessibility Changes

### DIFF
--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -511,6 +511,13 @@ consvar_t cv_applylocalencore = Player("localencore", "Off").values({{0, "Off"},
 // Observation Haki
 consvar_t cv_applyhaki = Player("hakimode", "Off").values({{0, "Off"}, {1, "On"}}).dont_save().onchange_noinit(KartHaki_OnChange);
 
+// Rings Ghost Accessibility
+consvar_t cv_accessibility_rings_hide = Player("ringsaccessibility", "On").on_off();
+
+// Powerup jingle - straight from HOSTMOD, thanks Tyron.
+consvar_t cv_powersound = Player("powersoundhc", "Off").on_off();
+consvar_t cv_powersoundjoke = Player("powersoundjokehc", "On").on_off().onchange(KartExtraPowerSound_OnChange);
+
 consvar_t cv_show_riders_finish_ticker = Player("ridersfinishticker", "On").on_off().onchange_noinit(KartFinishLineTicker_OnChange);
 
 // Rumble Events
@@ -602,6 +609,10 @@ consvar_t cv_holdbuttonforscoreboard = Player("holdbuttonforscoreboard", "No").y
 consvar_t cv_inputdisplaytoggle = Player("inputdisplaytoggle", "Digital").values({
 	{'2', "Digital"}, 
 	{'4', "Analog"}
+});
+consvar_t cv_inputdisplaytogglesize = Player("inputdisplaytogglesize", "Mini").values({
+	{0, "Normal"}, 
+	{1, "Mini"}
 });
 
 consvar_t cv_toggle_timestamp_race = Player("racetimestamptoggle", "Default").values({

--- a/src/i_video_common.cpp
+++ b/src/i_video_common.cpp
@@ -48,6 +48,11 @@
 #include "st_stuff.h"
 #include "v_video.h"
 
+// RadioRacers
+#include "radioracers/rr_video.h"
+
+boolean isPingDrawn = false;
+
 extern "C" consvar_t cv_scr_scale, cv_scr_x, cv_scr_y;
 
 using namespace srb2;
@@ -113,20 +118,21 @@ static void postframe_update(Rhi& rhi)
 static void temp_legacy_finishupdate_draws()
 {
 	SCR_CalculateFPS();
+	isPingDrawn = false;
 	if (st_overlay)
 	{
 		if (cv_songcredits.value)
 			HU_DrawSongCredits();
-
-		if (cv_ticrate.value)
-			SCR_DisplayTicRate();
 
 		if (netgame && (consoleplayer != serverplayer || !server_lagless))
 		{
 			if (server_lagless)
 			{
 				if (consoleplayer != serverplayer)
+				{
 					SCR_DisplayLocalPing();
+					isPingDrawn = true;
+				}
 			}
 			else
 			{
@@ -134,6 +140,7 @@ static void temp_legacy_finishupdate_draws()
 				{
 					if (D_IsPlayerHumanAndGaming(player))
 					{
+						isPingDrawn = true;
 						SCR_DisplayLocalPing();
 						break;
 					}
@@ -141,7 +148,14 @@ static void temp_legacy_finishupdate_draws()
 			}
 		}
 		if (cv_mindelay.value && consoleplayer == serverplayer && Playing())
+		{
 			SCR_DisplayLocalPing();
+			isPingDrawn = true;
+		}
+
+		// RADIO: Changed fps/ping layout, so need to define a custom boolean to check if ping is being drawn
+		if (cv_ticrate.value)
+			SCR_DisplayTicRate();
 #ifdef SRB2_CONFIG_ENABLE_WEBM_MOVIES
 		M_AVRecorder_DrawFrameRate();
 #endif

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -2480,7 +2480,8 @@ void K_DrawKartPositionNumXY(
 static void K_DrawKartPositionNum(UINT8 num)
 {
 	UINT8 splitIndex = (r_splitscreen > 0) ? 1 : 0;
-	fixed_t scale = FRACUNIT;
+	// RADIO: It's pretty big already
+	fixed_t scale = FRACUNIT/2;
 	fixed_t fx = 0, fy = 0;
 	transnum_t trans = static_cast<transnum_t>(0);
 	INT32 fflags = 0;
@@ -2510,8 +2511,9 @@ static void K_DrawKartPositionNum(UINT8 num)
 	// pain and suffering defined below
 	if (!r_splitscreen)
 	{
+		const boolean isDrawingInput = gamestate == GS_LEVEL && cv_drawinput.value && cv_inputdisplaytogglesize.value;
 		fx = BASEVIDWIDTH << FRACBITS;
-		fy = BASEVIDHEIGHT << FRACBITS;
+		fy = (BASEVIDHEIGHT - (isDrawingInput ? 14 : 10)) << FRACBITS;
 		fflags = V_SNAPTOBOTTOM|V_SNAPTORIGHT;
 	}
 	else if (r_splitscreen == 1)	// for this splitscreen, we'll use case by case because it's a bit different.
@@ -5912,6 +5914,12 @@ static void K_drawInput(void)
 		mode = cv_inputdisplaytoggle.value;
 	}
 	mode += (r_splitscreen > 1);
+
+	if (cv_inputdisplaytogglesize.value) {
+		mode += 1;
+		def[k][0] = 290;
+		def[k][1] = 178;
+	}
 	bool local = !demo.playback && P_IsMachineLocalPlayer(stplyr);
 	fixed_t slide = K_GetDialogueSlide(FRACUNIT);
 	INT32 tallySlide = []() -> INT32
@@ -6731,6 +6739,12 @@ void K_drawKartHUD(void)
 			INT32 flags = V_HUDTRANS|V_SLIDEIN|V_SNAPTOTOP|V_SNAPTORIGHT;
 
 			tic_t realtime = stplyr->realtime;
+
+			// RADIO: Little thing
+			if (leveltime < starttime)
+			{
+				realtime = starttime - leveltime;
+			}
 
 			if (stplyr->karthud[khud_lapanimation]
 				&& !stplyr->exiting

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -9077,8 +9077,13 @@ void K_KartPlayerThink(player_t *player, ticcmd_t *cmd)
 
 	if ((player->respawn.state == RESPAWNST_NONE) && player->growshrinktimer != 0)
 	{
-		if (player->growshrinktimer > 0 && (onground == true || player->ignoreAirtimeLeniency > 0))
+		if (player->growshrinktimer > 0 && (onground == true || player->ignoreAirtimeLeniency > 0)) {
 			player->growshrinktimer--;
+
+			// RADIO: Directly from HOSTMOD for SRB2Kart, so credit to Tyron.
+			RR_PlayCountdownJingle(player->growshrinktimer, player);
+		}
+		
 		if (player->growshrinktimer < 0)
 			player->growshrinktimer++;
 

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -4443,6 +4443,9 @@ static void P_RefreshItemCapsuleParts(mobj_t *mobj)
 		part = part->tracer;
 		part->sprite = SPR_ITMN;
 		part->frame = FF_FULLBRIGHT|(count % 10);
+
+		// RADIO: Setting this boolean here
+		part->isSuperRingItemNumber = (itemType == KITEM_SUPERRING);
 		count /= 10;
 		numNumbers++;
 	}

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -451,6 +451,9 @@ struct mobj_t
 	INT32 po_movecount; // Polyobject carrying (NOT savegame, NOT Lua)
 
 	// WARNING: New fields must be added separately to savegame and Lua.
+
+	// RADIO
+	boolean isSuperRingItemNumber; // For item capsule numbers, no savegame or lua
 };
 
 //

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -75,6 +75,7 @@
 #include "acs/interface.h"
 
 #include "radioracers/rr_hud.h"
+#include "radioracers/rr_util.h"
 
 #ifdef HWRENDER
 #include "hardware/hw_light.h"
@@ -1791,6 +1792,9 @@ static void P_CheckInvincibilityTimer(player_t *player)
 	if (!player->invincibilitytimer)
 		return;
 
+	// RADIO: Directly from HOSTMOD for SRB2Kart, so credit to Tyron.
+	RR_PlayCountdownJingle(player->invincibilitytimer, player);
+	
 	// Resume normal music stuff.
 	if (player->invincibilitytimer == 1)
 	{

--- a/src/r_things.cpp
+++ b/src/r_things.cpp
@@ -55,6 +55,7 @@
 
 // Radio Racers
 #include "radioracers/rr_cvar.h"
+#include "radioracers/rr_util.h"
 
 #define MINZ (FRACUNIT*4)
 #define BASEYCENTER (BASEVIDHEIGHT/2)
@@ -940,7 +941,10 @@ static void R_DrawVisSprite(vissprite_t *vis)
 	R_SetColumnFunc(BASEDRAWFUNC, false); // hack: this isn't resetting properly somewhere.
 	dc.colormap = vis->colormap;
 	dc.fullbright = colormaps;
-	dc.translation = R_GetSpriteTranslation(vis);
+
+	// RADIO: Can't manipulate the mobj's directly because that'll cause desyncs out the ass
+	boolean ghostMo = RR_ShouldGhostRing(vis->mobj) || RR_ShouldGhostRingboxes(vis->mobj);
+	dc.translation = (ghostMo) ? R_GetTranslationColormap(TC_RAINBOW, static_cast<skincolornum_t>(SKINCOLOR_NICKEL), GTC_CACHE) : R_GetSpriteTranslation(vis);
 
 	// Hack: Use a special column function for drop shadows that bypasses
 	// invalid memory access crashes caused by R_ProjectDropShadow putting wrong values
@@ -2169,6 +2173,10 @@ static void R_ProjectSprite(mobj_t *thing)
 		sort_y = FixedMul(FixedMul(FixedMul(spriteyscale, this_scale), sort_z), FINESINE(ang));
 	}
 
+	if (RR_ShouldGhostItemCapsuleNumbers(thing)) {
+		return;
+	}
+
 	if ((thing->flags2 & MF2_LINKDRAW) && thing->tracer) // toast 16/09/16 (SYMMETRY)
 	{
 		interpmobjstate_t tracer_interp = {0};
@@ -2272,6 +2280,9 @@ static void R_ProjectSprite(mobj_t *thing)
 		if (trans >= NUMTRANSMAPS)
 			return; // cap
 	}
+
+	if (RR_ShouldGhostRing(thing) || RR_ShouldGhostRingboxes(thing) || RR_ShouldGhostItemCapsuleParts(thing))
+		trans = (RF_TRANS60 & RF_TRANSMASK) >> RF_TRANSSHIFT;
 
 	// Check if this sprite needs to be rendered like a shadow
 	shadowdraw = (!!(thing->renderflags & RF_SHADOWDRAW) && !(papersprite || splat));

--- a/src/radioracers/cvar/rr_cvar.cpp
+++ b/src/radioracers/cvar/rr_cvar.cpp
@@ -39,6 +39,22 @@ void KartHaki_OnChange(void)
     CONS_Printf(M_GetText("Your observation haki will be turned \x82%s\x80 next round.\n"), cv_applyhaki.string);
 }
 
+void KartExtraPowerSound_OnChange(void)
+{
+    boolean extra_power_sound = (boolean)cv_powersoundjoke.value;
+    if (extra_power_sound)
+    {
+        if ((!found_radioracers || radio_last_powerup_jingle_sound == sfx_None) ) {
+            CONS_Alert(
+                CONS_NOTICE,
+                M_GetText("This feature cannot be enabled, missing the sound lump.\n")
+            );
+            CV_StealthSetValue(&cv_powersoundjoke, 0);
+            return;
+        }
+    }
+}
+
 void KartFinishLineTicker_OnChange(void)
 {
     // Immediately empty the queue

--- a/src/radioracers/hud/rr_setup.cpp
+++ b/src/radioracers/hud/rr_setup.cpp
@@ -64,6 +64,7 @@ boolean radioracers_useendkey = false;
 patch_t* end_key[2];
 
 sfxenum_t radio_ding_sound;
+sfxenum_t radio_last_powerup_jingle_sound; // Very important
 
 /**
  * 300 frames is really generous. 
@@ -943,6 +944,9 @@ void RR_Init(void) {
     if (found_radioracers) {
         // Yeah
         radio_ding_sound = S_AddSoundFx("emenup", false, 0, false);
+
+        // VERY important
+        radio_last_powerup_jingle_sound = S_AddSoundFx("pujvlj", false, 0, false);
     
         // Mute icon for Pause Menu
         if (W_LumpExists("M_ICOMUT") && W_LumpExists("M_ICOMU2")) {

--- a/src/radioracers/hud/rr_timer.cpp
+++ b/src/radioracers/hud/rr_timer.cpp
@@ -100,7 +100,7 @@ void RR_DrawKartMiniTimestamp(tic_t drawtime, INT32 TX, INT32 TY, INT32 splitfla
         V_DrawThinTimerString(TX+12, TY+3, splitflags, va("'"));
 
         // quotation mark location    _ __"__
-        V_DrawTimerString(TX+30, TY+3, splitflags, va("\""));
+        V_DrawThinTimerString(TX+30, TY+3, splitflags, va("\""));
     }
     else
     {

--- a/src/radioracers/menus/rr_menus.c
+++ b/src/radioracers/menus/rr_menus.c
@@ -20,12 +20,6 @@
 // HUD Options - Race
 static menuitem_t OPTIONS_RadioRacersHudRace[] =
 {
-	{IT_STRING | IT_CVAR, "Ring Counter Position", "Toggle the RING COUNTER's HUD position.",
-		NULL, {.cvar = &cv_ringsonplayer}, 0, 0},
-
-	{IT_STRING | IT_CVAR, "Ring Counter Overflow", "Show/hide overflow text on RING COUNTER.",
-		NULL, {.cvar = &cv_toggle_rings_excess}, 0, 0},
-
 	{IT_HEADER, "Toggle HUD Elements", NULL,
 		NULL, {NULL}, 0, 0},
 
@@ -139,11 +133,23 @@ menuitem_t OPTIONS_RadioRacersHud[] =
 	{IT_SPACE | IT_NOTHING, NULL,  NULL,
 		NULL, {NULL}, 0, 0},
 
+	{IT_HEADER, "Ring Counter Options", NULL,
+		NULL, {NULL}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Ring Counter Position", "Toggle the RING COUNTER's HUD position.",
+		NULL, {.cvar = &cv_ringsonplayer}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Ring Counter Overflow", "Show/hide overflow text on RING COUNTER.",
+		NULL, {.cvar = &cv_toggle_rings_excess}, 0, 0},
+
 	{IT_HEADER, "General Options", NULL,
 		NULL, {NULL}, 0, 0},
 
 	{IT_STRING | IT_CVAR, "Input Display Type", "Toggle between the DIGITAL and ANALOG controller types in the input display.",
 		NULL, {.cvar = &cv_inputdisplaytoggle}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Input Display Size", "Toggle the size of the input display size",
+		NULL, {.cvar = &cv_inputdisplaytogglesize}, 0, 0},
 
 	{IT_STRING | IT_CVAR, "Hold Rankings Button", "Press and hold the rankings button to view the rankings, just like in SRB2Kart.",
 		NULL, {.cvar = &cv_holdbuttonforscoreboard}, 0, 0},
@@ -184,6 +190,53 @@ menu_t OPTIONS_RadioRacersHudDef = {
 	M_DrawOptionsCogs,
 	M_OptionsTick,
 	Roulette_OnChange,
+	NULL,
+	NULL,
+};
+
+// Accessibility
+static menuitem_t OPTIONS_RadioRacersAccessibility[] =
+{
+	{IT_STRING | IT_CVAR, "Observation Haki", "Apply a grayscale filter to the level, keeping important elements in colour.",
+		NULL, {.cvar = &cv_applyhaki}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Ghost Rings", "Ghost rings and ringboxes when you're unable to collect any rings.",
+		NULL, {.cvar = &cv_accessibility_rings_hide}, 0, 0},
+
+	{IT_SPACE | IT_NOTHING, NULL,  NULL,
+		NULL, {NULL}, 0, 0},
+	
+	{IT_HEADER, "Powerups", NULL,
+		NULL, {NULL}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Powerup Countdown Jingle", "Play an audible countdown when your invincibility/grow powerup is about to end.",
+		NULL, {.cvar = &cv_powersound}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Extra Countdown Jingle", "Play an extra sound on the last second the coutdown jingle.",
+		NULL, {.cvar = &cv_powersoundjoke}, 0, 0},
+};
+
+void RadioAccessibilityMenu_Init(void)
+{
+	if (!found_radioracers || radio_last_powerup_jingle_sound == sfx_None) {
+		OPTIONS_RadioRacersAccessibility[5].status = IT_GRAYEDOUT;	
+	}
+}
+
+static menu_t OPTIONS_RadioRacersAccessibilityDef = {
+	sizeof (OPTIONS_RadioRacersAccessibility) / sizeof (menuitem_t),
+	&OPTIONS_RadioRacersMenuDef,
+	0,
+	OPTIONS_RadioRacersAccessibility,
+	48, 80,
+	SKINCOLOR_SUNSLAM, 0,
+	MBF_DRAWBGWHILEPLAYING,
+	NULL,
+	2, 5,
+	M_DrawGenericOptions,
+	M_DrawOptionsCogs,
+	M_OptionsTick,
+	RadioAccessibilityMenu_Init,
 	NULL,
 	NULL,
 };
@@ -246,11 +299,8 @@ static menu_t OPTIONS_RadioRacersGameplayDef = {
 // Fun features
 static menuitem_t OPTIONS_RadioRacersFun[] =
 {
-	{IT_STRING | IT_CVAR, "Enable Encore Palettes", "Toggle encore palettes clientside for levels, if available.",
+	{IT_STRING | IT_CVAR, "Enable Encore Palettes (Clientside)", "Toggle encore palettes clientside for levels, if available.",
 		NULL, {.cvar = &cv_applylocalencore}, 0, 0},
-
-	{IT_STRING | IT_CVAR, "Observation Haki", "Apply a grayscale filter to the level, keeping important elements in colour.",
-		NULL, {.cvar = &cv_applyhaki}, 0, 0},
 
 	{IT_STRING | IT_CVAR, "Riders Finish Line Ticker", "Show a finish line ticker, like in Sonic Riders!",
 		NULL, {.cvar = &cv_show_riders_finish_ticker}, 0, 0},
@@ -289,6 +339,9 @@ menuitem_t OPTIONS_RadioRacersMenu[] =
 
 	{IT_STRING | IT_SUBMENU, "Gameplay..", "Gameplay-enhancing options.",
 		NULL, {.submenu = &OPTIONS_RadioRacersGameplayDef}, 0, 0},
+
+	{IT_STRING | IT_SUBMENU, "Accessibility..", "Accessibility options.",
+		NULL, {.submenu = &OPTIONS_RadioRacersAccessibilityDef}, 0, 0},
 
 	{IT_STRING | IT_SUBMENU, "\\(^_^)/", "Fun stuff!",
 		NULL, {.submenu = &OPTIONS_RadioRacersFunDef}, 0, 0},
@@ -350,7 +403,7 @@ void Roulette_OnChange(void)
 
 	UINT16 newstatus = (cv_rouletteonplayer.value) ? IT_STRING | IT_CVAR : IT_GRAYEDOUT;
 
-	for (int i = 9; i < 13; i++) {
+	for (int i = 13; i < 17; i++) {
 		OPTIONS_RadioRacersHud[i].status = newstatus;
 	}
 }

--- a/src/radioracers/netgame/rr_votesnitch.c
+++ b/src/radioracers/netgame/rr_votesnitch.c
@@ -29,7 +29,7 @@ void RR_VoteSnitchNewVote(midVoteType_e type, player_t *victim, player_t *caller
 	const char *levelTitle = mapheaderinfo[gamemap-1]->lvlttl;
 	switch (type){
 		case MVT_KICK: // Kick
-			voteReason = va("\x82KICK \x89%s \x86", player_names[victim - players]);
+			voteReason = va("\x82KICK \x89%s\x86", player_names[victim - players]);
 			break;
 		case MVT_RTV: // Skip
 			if (*levelTitle != '\0') {

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -26,7 +26,12 @@ extern consvar_t cv_votesnitch;         // Vote Snitch
 extern consvar_t cv_ringsonplayer;      // Rings drawn on player
 extern consvar_t cv_rouletteonplayer;   // Item/Ring Roulette drawn on player
 extern consvar_t cv_applylocalencore;    // Clientside encore palettes
+
+// Accessibility
 extern consvar_t cv_applyhaki;           // Observation Haki mode
+extern consvar_t cv_accessibility_rings_hide; // Ghost rings and ringboxes when you're unable to collect any rings.
+extern consvar_t cv_powersound; // Straight from HOSTMOD, thanks Tyron
+extern consvar_t cv_powersoundjoke;
 
 // Battle
 extern consvar_t cv_customemeraldhud;    // Alternate Emerald display for Battle Mode
@@ -37,6 +42,7 @@ extern consvar_t cv_targetrackplayers;  // Toggle the TARGET HUD graphics for ot
 
 void KartLocalEncore_OnChange(void);
 void KartHaki_OnChange(void);
+void KartExtraPowerSound_OnChange(void);
 void KartFinishLineTicker_OnChange(void);
 void RR_ChatEmotes_OnChange(void);
 void RR_ChatEmoteSort_OnChange(void);
@@ -72,6 +78,7 @@ extern consvar_t cv_hud_hidelapemblem; // Hide the bigass lap emblem when you st
 extern consvar_t cv_hud_usehighresportraits; // Draw higher-res portraits in the minirankings
 extern consvar_t cv_holdbuttonforscoreboard; // Restore SRB2Kart behaviour when viewing in-game scoreboards
 extern consvar_t cv_inputdisplaytoggle; // Toggle betweeen DIGITAL and ANALOG input display controller
+extern consvar_t cv_inputdisplaytogglesize; // Toggle controller display size (mini or big)
 extern consvar_t cv_show_riders_finish_ticker; // Show the Sonic Riders :tm: finish line ticker
 extern consvar_t cv_chat_emotes;                    // Self-explanatory
 extern consvar_t cv_chat_emotes_animated;           // Should emotes animate?

--- a/src/radioracers/rr_menu.h
+++ b/src/radioracers/rr_menu.h
@@ -31,6 +31,7 @@ extern menuitem_t OPTIONS_RadioRacersHud[];
 extern menu_t OPTIONS_RadioRacersHudDef;
 
 void RadioFunMenu_Init(void);
+void RadioAccessibilityMenu_Init(void);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/radioracers/rr_setup.h
+++ b/src/radioracers/rr_setup.h
@@ -22,6 +22,7 @@ extern boolean radioracers_usehakiencore;
 extern boolean radioracers_useendkey;
 extern patch_t *end_key[2];
 extern sfxenum_t radio_ding_sound;
+extern sfxenum_t radio_last_powerup_jingle_sound;
 extern void RR_Init(void);
 extern void RR_AddAllEmotes(UINT16 wadnum);
 extern void RR_CleanupEmoteFrames(void);

--- a/src/radioracers/rr_util.h
+++ b/src/radioracers/rr_util.h
@@ -25,6 +25,13 @@ typedef enum {
 extern int scaleInt(int value, fixed_t scale);
 extern void RR_HandleBlueSphereRumble(player_t *player);
 extern void RR_AnnounceBattleWinner(player_t *player, battle_win_type_t type);
+extern void RR_PlayCountdownJingle(INT16 timer, player_t *player);
+extern boolean RR_ShouldGhostRing(mobj_t *mo);
+extern boolean RR_ShouldGhostRingboxes(mobj_t *mo);
+extern boolean RR_ShouldGhostItemCapsuleParts(mobj_t* mo);
+extern boolean RR_ShouldGhostItemCapsuleNumbers(mobj_t *mo);
+
+#define IS_BEING_CHASED_BY_SPB(p) (p->pflags & PF_RINGLOCK)
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/radioracers/rr_video.h
+++ b/src/radioracers/rr_video.h
@@ -102,9 +102,10 @@ extern "C" {
 #define EMOTE_PADDING 1
 #define GET_CHAT_EMOTE_SCALE(h, has_text) (((has_text) ? MAX_HEIGHT_WITH_TEXT : MAX_HEIGHT)/static_cast<float_t>(h))
 
-// Thin timer font isn't used anywhere
 #define V_DrawThinTimerString( x,y,option,string ) \
 	V__DrawDupxString (x,y,FRACUNIT,option,NULL,TINYTIMER_FONT,string)
+
+extern boolean isPingDrawn;
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/radioracers/util/rr_util.c
+++ b/src/radioracers/util/rr_util.c
@@ -12,10 +12,12 @@
 #include "../../doomstat.h" // encoremode, localencore
 #include "../rr_util.h" // encoremode, localencore
 #include "../rr_cvar.h"
+#include "../rr_setup.h"
 #include "../rr_controller.h"
 #include "../../p_local.h"
 #include "../../hu_stuff.h"
 #include "../../g_game.h"
+#include "../../s_sound.h"
 
 boolean shouldApplyEncore(void)
 {
@@ -65,6 +67,75 @@ void RR_AnnounceBattleWinner(player_t *player, battle_win_type_t type)
 
     // va causes crashes sometimes but ONLY semi-rarely, weird.
     HU_DoCEcho(va(BATTLE_WIN_MESSAGES[type], player_names[player-players]));    
+}
+
+void RR_PlayCountdownJingle(INT16 timer, player_t *player) {
+    if (!cv_powersound.value)
+        return;
+
+    if (stplyr != player)
+        return;
+
+    if (timer > 0 && timer <= 3 * TICRATE)
+    {
+        if (timer % TICRATE == 0)
+        {
+            S_StartSound(NULL, sfx_s242);
+            
+            // (skypegiggle)
+            if (found_radioracers && cv_powersoundjoke.value && radio_last_powerup_jingle_sound != sfx_None && timer == TICRATE) {
+                S_StartSoundAtVolume(NULL, radio_last_powerup_jingle_sound, 255/4);
+            }
+        }
+    }
+}
+	
+static boolean isRing(mobj_t* mo)
+{
+    return (mo->type == MT_RING || mo->type == MT_FLINGRING);
+}
+static boolean isRingBox(mobj_t* mo)
+{
+    statenum_t specialstate = mo->state - states;
+    return (mo->type == MT_RANDOMITEM) && (specialstate >= S_RINGBOX1 && specialstate <= S_RINGBOX12);
+}
+
+static boolean canGhost(void)
+{
+    return cv_accessibility_rings_hide.value && r_splitscreen == 0;
+}
+
+boolean RR_ShouldGhostRing(mobj_t *mo)
+{
+    return canGhost() &&
+    isRing(mo) && 
+    !(!P_MobjWasRemoved(mo->target) && mo->target->type == MT_PLAYER) && 
+    (IS_BEING_CHASED_BY_SPB(stplyr) || RINGTOTAL(stplyr) >= 20);
+}
+
+boolean RR_ShouldGhostRingboxes(mobj_t *mo)
+{
+    return canGhost() &&
+    isRingBox(mo) && 
+    (IS_BEING_CHASED_BY_SPB(stplyr));
+}
+
+boolean RR_ShouldGhostItemCapsuleParts(mobj_t *mo)
+{
+    return canGhost() &&
+    (
+        (mo->type == MT_ITEMCAPSULE_PART && (mo->sprite == SPR_ITEM && mo->frame & KITEM_SUPERRING)) ||
+        (mo->type == MT_ITEMCAPSULE)
+    ) &&
+    IS_BEING_CHASED_BY_SPB(stplyr);
+}
+
+boolean RR_ShouldGhostItemCapsuleNumbers(mobj_t *mo)
+{
+    // isSuperRingItemNumber is only set to true in p_mobj.c in P_RefreshItemCapsuleParts
+    return canGhost() && 
+    mo->isSuperRingItemNumber &&
+    IS_BEING_CHASED_BY_SPB(stplyr);
 }
 
 int scaleInt(int value, fixed_t scale)

--- a/src/screen.c
+++ b/src/screen.c
@@ -45,6 +45,9 @@
 // SRB2Kart
 #include "r_fps.h" // R_GetFramerateCap
 
+// RadioRacers
+#include "radioracers/rr_video.h"
+
 #if defined (USEASM) && !defined (NORUSEASM)//&& (!defined (_MSC_VER) || (_MSC_VER <= 1200))
 #define RUSEASM //MSC.NET can't patch itself
 #endif
@@ -531,6 +534,21 @@ void SCR_DisplayTicRate(void)
 	UINT32 cap = R_GetFramerateCap();
 	UINT32 benchmark = (cap == 0) ? I_GetRefreshRate() : cap;
 	INT32 x = 317;
+	const boolean isDrawingInput = gamestate == GS_LEVEL && cv_drawinput.value && cv_inputdisplaytogglesize.value;
+	const boolean isDrawingPing = isPingDrawn && r_splitscreen == 0;
+
+	if (isDrawingPing)
+	{
+		x = 297;
+		// if (isDrawingInput)
+		// 	x -= 10;
+	}
+	
+	if (isDrawingInput)
+	{
+		x -= (isDrawingPing) ? 28 : 27;
+	}
+	
 	double fps = round(averageFPS);
 
 	if (fps > (benchmark * 0.9))
@@ -580,10 +598,16 @@ void SCR_DisplayLocalPing(void)
 	UINT32 mindelay = playerdelaytable[consoleplayer];
 	UINT32 ping = playerpingtable[consoleplayer];
 	UINT32 pl = playerpacketlosstable[consoleplayer];
+	
+	// RADIO: To the side looks cleaner then showing it vertically
+	// INT32 dispy = cv_ticrate.value ? 170 : 181;
+	INT32 dispy = 189;
+	INT32 dispx = 298;
 
-	INT32 dispy = cv_ticrate.value ? 170 : 181;
+	if (gamestate == GS_LEVEL && cv_drawinput.value && cv_inputdisplaytogglesize.value)
+		dispx = 270;
 
-	HU_drawPing(307 * FRACUNIT, dispy * FRACUNIT, ping, mindelay, pl, V_SNAPTORIGHT | V_SNAPTOBOTTOM, 0);
+	HU_drawPing(dispx * FRACUNIT, dispy * FRACUNIT, ping, mindelay, pl, V_SNAPTORIGHT | V_SNAPTOBOTTOM, 1);
 }
 
 


### PR DESCRIPTION
+ Accessibility menu under `Radio Options`
![image](https://github.com/user-attachments/assets/4a30044f-a487-42ce-bfff-25301578a1ab)
<sup>* Moved `Observation Haki` to Accessibility Options</sup>

| Setting | Description |
| -------- | ------- |
| Ghost Rings| Ghost rings and ringboxes when you're unable to collect any rings.  |
| Powerup Countdown Jingle |Play an audible countdown when your invincibility/grow powerup is about to end. |
| Extra Countdown Jingle | Play an extra sound on the last second the coutdown jingle.|

### Ghost Rings
Draw rings, item capsules _with_ super rings and ringboxes as intangible when the player is unable to collect any rings - this will be when you have the maximum amount of rings or when you're being chased by an SPB.

https://github.com/user-attachments/assets/f21d93ad-107a-4af0-a8af-5edad85629d5

![image](https://github.com/user-attachments/assets/bc8abc6b-d6b1-483d-ba92-f834b03e6030)


### Powerup Countdown Jingle
Anonymous request - a backport of the `powersound` jingle feature from [HOSTMOD](https://hyuu.cc/hostmod/) by [Tyron](https://mb.srb2.org/threads/hostmod.26649/).

https://github.com/user-attachments/assets/afc84bd8-4834-479f-93a7-04f0806a146d

#### Extra Countdown Jingle
Play an extra optional sound on the _last_ second during the countdown jingle.
