### PR TITLE
Add item timers accessibility feature

### DIFF
--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -514,9 +514,12 @@ consvar_t cv_applyhaki = Player("hakimode", "Off").values({{0, "Off"}, {1, "On"}
 // Rings Ghost Accessibility
 consvar_t cv_accessibility_rings_hide = Player("ringsaccessibility", "On").on_off();
 
+// Item timers (not all)
+consvar_t cv_gingeritemtimers = Player("huditemtimers", "On").on_off();
+
 // Powerup jingle - straight from HOSTMOD, thanks Tyron.
 consvar_t cv_powersound = Player("powersoundhc", "Off").on_off();
-consvar_t cv_powersoundjoke = Player("powersoundjokehc", "On").on_off().onchange(KartExtraPowerSound_OnChange);
+consvar_t cv_powersoundjoke = Player("powersoundjokehc", "On").on_off().onchange_noinit(KartExtraPowerSound_OnChange);
 
 consvar_t cv_show_riders_finish_ticker = Player("ridersfinishticker", "On").on_off().onchange_noinit(KartFinishLineTicker_OnChange);
 

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -6741,7 +6741,7 @@ void K_drawKartHUD(void)
 			tic_t realtime = stplyr->realtime;
 
 			// RADIO: Little thing
-			if (leveltime < starttime)
+			if (leveltime < starttime && gametype == GT_RACE)
 			{
 				realtime = starttime - leveltime;
 			}
@@ -7060,7 +7060,11 @@ void K_drawKartHUD(void)
 		K_drawMiniPing();
 	}
 
-	K_drawKartPowerUps();
+	if (cv_gingeritemtimers.value) {
+		RR_DrawItemTimers();
+	} else {
+		K_drawKartPowerUps();
+	}
 
 	if (K_DirectorIsAvailable(viewnum) == true && LUA_HudEnabled(hud_textspectator))
 	{

--- a/src/radioracers/hud/CMakeLists.txt
+++ b/src/radioracers/hud/CMakeLists.txt
@@ -4,4 +4,5 @@ target_sources(SRB2SDL2 PRIVATE
 	rr_setup.cpp
 	rr_emotes.cpp
 	rr_timer.cpp
+	rr_item_timers.cpp
 )

--- a/src/radioracers/hud/rr_item_timers.cpp
+++ b/src/radioracers/hud/rr_item_timers.cpp
@@ -1,0 +1,221 @@
+// RadioRacers
+//-----------------------------------------------------------------------------
+// Copyright (C) 2025 by $HOME
+//
+// This program is free software distributed under the
+// terms of the GNU General Public License, version 2.
+// See the 'LICENSE' file for more details.
+//-----------------------------------------------------------------------------
+/// \file radioracers/rr_item_timers.cpp
+/// \brief Backporting a debugging script I wrote back in 2020
+
+#include <algorithm>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "../rr_hud.h"
+#include "../../doomstat.h"
+#include "../../p_local.h"
+#include "../../g_game.h"
+#include "../../k_color.h"
+#include "../../k_powerup.h"
+#include "../../v_draw.hpp"
+#include "../../core/static_vec.hpp"
+
+using srb2::Draw;
+
+constexpr const int HARD_Y = 180;
+constexpr const int HARD_X = 160;
+constexpr const int SHIFT_X = 17; // To the left, to the left
+
+const std::vector start_boost_patches = {"DBOSA5", "DBOSB5", "DBOSC5"};
+const std::vector drift_patches = {"DRIFC3C7", "DRIFD3D7", "DRIFA3A7"};
+
+// STRUCTS
+
+struct ItemTimer
+{
+    INT32 time; // Timer.. time
+    std::string patch; // Item graphic
+    std::optional<float> patch_scale; // Item scale
+    std::pair<int, int> offsets; // Patch offset (x, y)
+    std::optional<UINT16> colormap; // Colormap
+
+    // Straight from Icon struct in powerup.cpp, thank you Jartha xoxoxo
+    bool operator<(const ItemTimer& b) const { return time < b.time; }
+    bool operator>(const ItemTimer& b) const { return time > b.time; }
+};
+
+// STRUCTS
+
+
+static UINT16 getDriftSparkColor(void) {
+    if (stplyr->driftboost > 125) { // Rainbow sparks
+        return K_RainbowColor(leveltime);
+    } else if (stplyr->driftboost > 85) { // Blue sparks
+        return SKINCOLOR_BLUE;
+    } else if (stplyr->driftboost > 50) { // Red sparks
+        return SKINCOLOR_KETCHUP;
+    } else if (stplyr-> driftboost > 20) { // Yellow sparks
+        return SKINCOLOR_GOLD;
+    }
+    return SKINCOLOR_GREY; // Gray sparks
+}
+
+std::vector<ItemTimer> getTimers(void) {
+    std::vector<ItemTimer> timers;
+
+    // Invincibility
+    if (!(gametyperules & GTR_POINTLIMIT)) {
+        const std::string invincibility_patch = fmt::format("K_ISINV{0}", (((leveltime % (6*3)) / 3) + 1));
+        timers.push_back({stplyr->invincibilitytimer, invincibility_patch});
+    }
+
+    // Grow
+    if (stplyr->growshrinktimer > 0)
+        timers.push_back({stplyr->growshrinktimer, "K_ISGROW"});
+
+    // Shrink
+    if (stplyr->growshrinktimer < 0) 
+        timers.push_back({abs(stplyr->growshrinktimer), "K_ISSHRK"});
+
+    // Ring boost
+    timers.push_back({stplyr->ringboost, "K_ISRING"});
+    
+    // Boost
+    timers.push_back({stplyr->sneakertimer, "K_ISSHOE"});
+
+    // Drift charge
+    
+    std::pair<int, int> drift_patches_offsets = {12, 17};
+    
+    int drift_index = (leveltime % drift_patches.size());
+    float drift_patch_scale = 0.3;
+
+    // If the player's drift charge is less than stage two, draw the first two patches only.
+    // And draw at a slightly smaller scale.
+    // Conveys less intensity.
+    if (stplyr-> driftboost <= 20) {
+        drift_index = ((leveltime % ((drift_patches.size()-1)*2)) / 2);
+        drift_patch_scale = 0.2;
+    }
+
+    const std::string drift_patch = drift_patches[drift_index];
+
+    timers.push_back({
+        stplyr->driftboost, 
+        drift_patch, 
+        drift_patch_scale, 
+        drift_patches_offsets,
+        getDriftSparkColor()
+    });
+
+    // Start boost
+    timers.push_back({
+        stplyr->startboost, 
+        start_boost_patches[leveltime % start_boost_patches.size()], 
+        0.2, 
+        {14, 17}, 
+        K_RainbowColor(leveltime)
+    });
+
+    // FAULT!
+    if (stplyr->pflags & PF_VOID) {
+        timers.push_back({stplyr->mo->hitlag, "K_NOBLNS", {}, {7, 6}});
+    }
+
+    // Battle powerups
+    if (gametyperules & GTR_POINTLIMIT) {
+        for (int k = FIRSTPOWERUP; k < ENDOFPOWERUPS; ++k)
+        {
+            const kartitems_t powerup = static_cast<kartitems_t>(k);
+            const int letter = 'A' + (powerup - FIRSTPOWERUP); 
+
+            timers.push_back({
+                static_cast<INT32>(K_PowerUpRemaining(stplyr, powerup)),
+                fmt::format("PWRS{0:c}L{0:c}R", letter),
+                {},
+                {15, 18},
+                stplyr->skincolor
+            });
+        }
+    }
+
+    // And, sort.
+    std::stable_sort(timers.begin(), timers.end(), std::greater<ItemTimer>());
+
+    return timers;
+}
+
+/**
+ * Draw item timers for the stplyr (you) in the bottom-middle of the screen.
+ */
+void RR_DrawItemTimers(void)
+{   
+    /**
+     * Not supporting splitscreen, never ever
+     * Don't bother drawing these in a race.. space is occupied by the battle timers 
+     */
+    if (r_splitscreen > 0 || (P_MobjWasRemoved(stplyr->mo) || stplyr->mo == NULL || stplyr->exiting))
+        return;
+
+    std::vector<ItemTimer> timers = getTimers();
+
+    INT32 start_x = HARD_X;
+    INT32 x_offset = -SHIFT_X;
+    for (const ItemTimer& t : timers) {
+        if (t.time <= 0)
+            continue;
+        x_offset += SHIFT_X;
+    }
+    start_x -= (x_offset / 2);
+
+    const INT32 draw_flags = V_SNAPTOBOTTOM;
+
+    Draw timer_row = Draw(start_x, HARD_Y)
+        .font(Draw::Font::kThin)
+        .align(Draw::Align::kCenter)
+        .flags(draw_flags);
+    
+    for (const ItemTimer& t : timers) {
+        if (t.time <= 0) continue;
+
+        const INT32 centiseconds = G_TicsToCentiseconds(t.time);
+        const INT32 seconds = G_TicsToSeconds(t.time);
+        INT32 extra_flags = draw_flags;
+
+        // Slow fade out
+        if (seconds == 0 && centiseconds <= 9) {                
+            extra_flags |= (static_cast<transnum_t>(abs(centiseconds - 10)) << V_ALPHASHIFT);
+        }
+
+        // First the graphic
+        int graphic_x = -15;
+        int graphic_y = -10;
+
+        // If a patch doesn't have offsets, the pair will default to {0, 0}
+        graphic_x += t.offsets.first;
+        graphic_y += t.offsets.second;
+
+        timer_row
+            .xy(graphic_x, graphic_y)
+            .scale(t.patch_scale.has_value() ? t.patch_scale.value() : 0.6)
+            .colormap(t.colormap.has_value()? t.colormap.value(): SKINCOLOR_NONE)
+            .flags(extra_flags)
+            .patch(t.patch);
+
+        // Then the time
+        timer_row
+            .y(10)
+            .scale(0.7)
+            .flags(extra_flags)
+            .text("{}.{}", seconds, centiseconds);
+
+        // And shift
+        timer_row = timer_row.x(SHIFT_X);
+    }
+    
+}

--- a/src/radioracers/menus/rr_menus.c
+++ b/src/radioracers/menus/rr_menus.c
@@ -203,6 +203,9 @@ static menuitem_t OPTIONS_RadioRacersAccessibility[] =
 	{IT_STRING | IT_CVAR, "Ghost Rings", "Ghost rings and ringboxes when you're unable to collect any rings.",
 		NULL, {.cvar = &cv_accessibility_rings_hide}, 0, 0},
 
+	{IT_STRING | IT_CVAR, "Item Timers", "Show item timers in the middle-bottom of your HUD.",
+		NULL, {.cvar = &cv_gingeritemtimers}, 0, 0},
+
 	{IT_SPACE | IT_NOTHING, NULL,  NULL,
 		NULL, {NULL}, 0, 0},
 	

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -32,6 +32,7 @@ extern consvar_t cv_applyhaki;           // Observation Haki mode
 extern consvar_t cv_accessibility_rings_hide; // Ghost rings and ringboxes when you're unable to collect any rings.
 extern consvar_t cv_powersound; // Straight from HOSTMOD, thanks Tyron
 extern consvar_t cv_powersoundjoke;
+extern consvar_t cv_gingeritemtimers; // Show certain item timers, old debugging tool from 2020
 
 // Battle
 extern consvar_t cv_customemeraldhud;    // Alternate Emerald display for Battle Mode

--- a/src/radioracers/rr_hud.h
+++ b/src/radioracers/rr_hud.h
@@ -294,6 +294,11 @@ void RR_DrawGradeEmote(player_grade_info_t grade_info);
  */
 extern void RR_DrawKartMiniTimestamp(tic_t drawtime, INT32 TX, INT32 TY, INT32 splitflags, UINT8 mode);
 
+/**
+ * Item timers
+ */
+extern void RR_DrawItemTimers(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
Backporting a debugging script from ~2020

![image](https://github.com/user-attachments/assets/4f78de27-0321-4705-8ae3-79e90a980cad)

Draw item timers in the middle-bottom screen of the current player (excl. splitscreen).