### PR TITLE
Fix ANIMDEFS.customtripwire

### DIFF
--- a/radio/pk3/src/radioracers/ANIMDEFS.customtripwire
+++ b/radio/pk3/src/radioracers/ANIMDEFS.customtripwire
@@ -1,2 +1,2 @@
 Texture BADTWIRE Range BDWRE54 Tics 1
-Texture GUDTWIRE Range GDWRE54 Tics 1
+Texture GDWRE00 Range GUDTWIRE Tics 1


### PR DESCRIPTION
fixes `I_Error(): P_InitPicAnims: bad cycle` on startup if radioracers.pk3 exists in root