### PR TITLE
Chore/update build config and libs

### DIFF
--- a/src/acs/vm/CMakeLists.txt
+++ b/src/acs/vm/CMakeLists.txt
@@ -10,7 +10,7 @@
 ##
 ##-----------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.14)
 
 cmake_policy(SET CMP0017 NEW)
 


### PR DESCRIPTION
Cherry-picked 1031066425987bc18c9be0fd426e0afc2f4184f2 and 6211e0560a2b04845f2ad6b63e682396f17e93c7 from the main Ring Racers branch, which fixes:

* The `libdivide` error stated in the attached issue
* CMake minimum version error when configuring the build with CMake