### PR TITLE
Extend muted player visibility across multiple points in the game

### DIFF
--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -3841,8 +3841,10 @@ static void Got_Teamchange(const UINT8 **cp, INT32 playernum)
 	{
 		CONS_Printf(M_GetText("%s switched to the %c%s%c.\n"), player_names[playernum], '\x84', M_GetText("Blue Team"), '\x80');
 	}
-	else if (NetPacket.packet.newteam == 0 && !wasspectator)
-		HU_AddChatText(va("\x82*%s became a spectator.", player_names[playernum]), false); // "entered the game" text was moved to P_SpectatorJoinGame
+	else if (NetPacket.packet.newteam == 0 && !wasspectator) {
+		const char* player_name = IsPlayerMuted(playernum) ? "???" : player_names[playernum];
+		HU_AddChatText(va("\x82*%s became a spectator.", player_name), false); // "entered the game" text was moved to P_SpectatorJoinGame
+	}
 
 	if (gamestate != GS_LEVEL || wasspectator == true)
 		return;

--- a/src/d_netcmd.c
+++ b/src/d_netcmd.c
@@ -1235,7 +1235,11 @@ static void Got_NameAndColor(const UINT8 **cp, INT32 playernum)
 
 					if (players[i].spectator)
 					{
-						HU_AddChatText(va("\x82*%s became a spectator.", player_names[playernum]), false);
+						const char* player_name = player_names[playernum];
+						if (IsPlayerMuted(playernum))
+							player_name = "???";
+						
+						HU_AddChatText(va("\x82*%s became a spectator.", player_name), false);
 
 						FinalisePlaystateChange(playernum);
 					}

--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -5092,7 +5092,7 @@ static void HWR_ProjectSprite(mobj_t *thing)
 	}
 
 	// Hide not-yet-unlocked characters in replays from other people
-	if (skinnum >= 0 && !R_CanShowSkinInDemo(skinnum))
+	if (skinnum >= 0 && (!R_CanShowSkinInDemo(skinnum) || RR_IsPlayerMutedForRndr(vis->mobj)))
 	{
 		vis->colormap = R_GetTranslationColormap(TC_BLINK, thing->color, GTC_CACHE);
 	}

--- a/src/hardware/hw_md2.c
+++ b/src/hardware/hw_md2.c
@@ -50,6 +50,9 @@
 #include "../k_hitlag.h" // HITLAGJITTERS
 #include "../r_fps.h"
 
+// Radio
+#include "../radioracers/rr_util.h"
+
 #ifdef HAVE_PNG
 
 #ifndef _MSC_VER
@@ -1529,7 +1532,7 @@ boolean HWR_DrawModel(gl_vissprite_t *spr)
 			}
 
 			// Hide not-yet-unlocked characters in replays from other people
-			if (skinnum >= 0 && !R_CanShowSkinInDemo(skinnum))
+			if (skinnum >= 0 && (!R_CanShowSkinInDemo(skinnum) || RR_IsPlayerMutedForRndr(spr->mobj)))
 			{
 				skinnum = TC_BLINK;
 			}

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -69,6 +69,7 @@
 #include "radioracers/rr_cvar.h" // cv_holdbuttonforscoreboard
 #include "radioracers/rr_hud.h"
 #include "radioracers/rr_video.h"
+#include "d_netcmd.h"
 #ifndef ENABLE_RADIO_DEMOS
 #include "radioracers/rr_demo.h"
 #endif
@@ -2739,8 +2740,10 @@ static inline void HU_DrawSpectatorTicker(void)
 	INT32 dupadjust = (vid.width/vid.dupx), duptweak = (dupadjust - BASEVIDWIDTH)/2;
 
 	for (i = 0; i < MAXPLAYERS; i++)
-		if (playeringame[i] && players[i].spectator)
-			totallength += (signed)strlen(player_names[i]) * 8 + 16;
+		if (playeringame[i] && players[i].spectator) {
+			const char* player_name = IsPlayerMuted(i) ? "???" : player_names[i];
+			totallength += (signed)strlen(player_name) * 8 + 16;
+		}
 
 	length -= (leveltime % (totallength + dupadjust+8));
 	length += dupadjust;
@@ -2754,9 +2757,12 @@ static inline void HU_DrawSpectatorTicker(void)
 			char current[MAXPLAYERNAME+1];
 			INT32 len;
 
-			len = ((signed)strlen(player_names[i]) * 8 + 16);
+			// Radio
+			const char* player_name = IsPlayerMuted(i) ? "???" : player_names[i];
 
-			strcpy(initial, player_names[i]);
+			len = ((signed)strlen(player_name) * 8 + 16);
+
+			strcpy(initial, player_name);
 			pos = initial;
 
 			if (length >= -len)

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -2797,10 +2797,16 @@ void PositionFacesInfo::draw_1p()
 			else
 				colormap = R_GetTranslationColormap(workingskin, static_cast<skincolornum_t>(players[rankplayer[i]].mo->color), GTC_CACHE);
 
+
+			patch_t * muted_facerank = static_cast<patch_t*>(W_CachePatchName("MISSING", GTC_CACHE));
+			const boolean is_muted = IsPlayerMuted(&players[rankplayer[i]] - players);
+
 			if (cv_hud_usehighresportraits.value) {
-				V_DrawSmallMappedPatch(FACE_X + xoff, Y + yoff, V_HUDTRANS|V_SLIDEIN|V_SNAPTOLEFT|flipflag, faceprefix[workingskin][FACE_WANTED], colormap);
+				patch_t *highresfacerank = (is_muted) ? muted_facerank : faceprefix[workingskin][FACE_WANTED];
+				V_DrawSmallMappedPatch(FACE_X + xoff, Y + yoff, V_HUDTRANS|V_SLIDEIN|V_SNAPTOLEFT|flipflag, highresfacerank, colormap);
 			} else {
-				V_DrawMappedPatch(FACE_X + xoff, Y + yoff, V_HUDTRANS|V_SLIDEIN|V_SNAPTOLEFT|flipflag, faceprefix[workingskin][FACE_RANK], colormap);
+				patch_t *facerank = (is_muted) ? muted_facerank : faceprefix[workingskin][FACE_RANK];
+				V_DrawMappedPatch(FACE_X + xoff, Y + yoff, V_HUDTRANS|V_SLIDEIN|V_SNAPTOLEFT|flipflag, facerank, colormap);
 			}
 			
 			if (LUA_HudEnabled(hud_battlebumpers))
@@ -4466,7 +4472,12 @@ static void K_DrawNameTagSphereMeter(INT32 x, INT32 y, INT32 width, INT32 sphere
 static void K_DrawNameTagForPlayer(fixed_t x, fixed_t y, player_t *p, INT32 flags)
 {
 	const INT32 clr = skincolors[p->skincolor].chatcolor;
-	const INT32 namelen = V_ThinStringWidth(player_names[p - players], 0);
+	const char* player_name = player_names[p - players];
+
+	if (IsPlayerMuted(p - players))
+		player_name = "???";
+	
+	const INT32 namelen = V_ThinStringWidth(player_name, 0);
 
 	UINT8 *colormap = V_GetStringColormap(clr);
 	INT32 barx = 0, bary = 0, barw = 0;
@@ -4525,7 +4536,7 @@ static void K_DrawNameTagForPlayer(fixed_t x, fixed_t y, player_t *p, INT32 flag
 	V_DrawFixedPatch(x, y, FRACUNIT, flags, kp_nametagstem, colormap);
 
 	// Draw the name itself
-	V_DrawThinStringAtFixed(x + (5*FRACUNIT), y - (26*FRACUNIT), clr|flags, player_names[p - players]);
+	V_DrawThinStringAtFixed(x + (5*FRACUNIT), y - (26*FRACUNIT), clr|flags, player_name);
 }
 
 playertagtype_t K_WhichPlayerTag(player_t *p)
@@ -5176,7 +5187,7 @@ static void K_drawKartMinimap(void)
 			{
 				skin = ((skin_t*)mobj->skin)-skins;
 
-				workingPic = R_CanShowSkinInDemo(skin) ? faceprefix[skin][FACE_MINIMAP] : kp_unknownminimap;
+				workingPic = R_CanShowSkinInDemo(skin) && !RR_IsPlayerMutedForRndr(mobj) ? faceprefix[skin][FACE_MINIMAP] : kp_unknownminimap;
 
 				if (mobj->color)
 				{
@@ -5388,7 +5399,7 @@ static void K_drawKartMinimap(void)
 		{
 			skin = ((skin_t*)mobj->skin)-skins;
 
-			workingPic = R_CanShowSkinInDemo(skin) ? faceprefix[skin][FACE_MINIMAP] : kp_unknownminimap;
+			workingPic = R_CanShowSkinInDemo(skin) && !RR_IsPlayerMutedForRndr(mobj) ? faceprefix[skin][FACE_MINIMAP] : kp_unknownminimap;
 
 			if (mobj->color)
 			{

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -76,6 +76,8 @@
 
 #include "radioracers/rr_hud.h"
 #include "radioracers/rr_util.h"
+#include "radioracers/rr_setup.h"
+#include "d_netcmd.h"
 
 #ifdef HWRENDER
 #include "hardware/hw_light.h"
@@ -3785,7 +3787,7 @@ boolean P_SpectatorJoinGame(player_t *player)
 	else if (changeto == 2)
 		text = va("\x82*%s switched to the %c%s%c team.\n", player_names[player-players], '\x85', "BLU", '\x82');
 	else
-		text = va("\x82*%s entered the game.", player_names[player-players]);
+		text = va("\x82*%s entered the game.", IsPlayerMuted(player-players) ? "???" : player_names[player-players]);
 
 	HU_AddChatText(text, false);
 	return true; // no more player->mo, cannot continue.

--- a/src/r_spritefx.cpp
+++ b/src/r_spritefx.cpp
@@ -15,6 +15,8 @@
 #include "r_splats.h"
 #include "r_things.h"
 
+#include "radioracers/rr_util.h"
+
 INT32 R_ThingLightLevel(mobj_t* thing)
 {
 	INT32 lightlevel = thing->lightlevel;
@@ -45,7 +47,12 @@ INT32 R_ThingLightLevel(mobj_t* thing)
 			lightlevel -= 255;
 		}
 
-		if (!R_CanShowSkinInDemo((skin_t*)thing->skin-skins)
+		// Radio: or hide muted players
+		if (
+			(
+				!R_CanShowSkinInDemo((skin_t*)thing->skin-skins) || 
+				RR_IsPlayerMutedForRndr(thing)
+			)
 		&& !thing->colorized
 		&& !thing->hitlag)
 		{

--- a/src/r_things.cpp
+++ b/src/r_things.cpp
@@ -856,7 +856,7 @@ UINT8 *R_GetSpriteTranslation(vissprite_t *vis)
 		skinnum = (skin_t*)vis->mobj->skin-skins;
 
 		// Hide not-yet-unlocked characters in replays from other people
-		if (!R_CanShowSkinInDemo(skinnum))
+		if (!R_CanShowSkinInDemo(skinnum) || RR_IsPlayerMutedForRndr(vis->mobj))
 		{
 			skinnum = TC_BLINK;
 		}

--- a/src/radioracers/hud/rr_feed.cpp
+++ b/src/radioracers/hud/rr_feed.cpp
@@ -34,6 +34,7 @@
 #include "../../info.h"
 #include "../../v_video.h"
 #include "../../command.h"
+#include "../../d_netcmd.h"
 #include "../../m_random.h"
 #include "../../v_draw.hpp" // srb2:Draw
 
@@ -650,6 +651,12 @@ static boolean canUseHudfeed(void) {
     return !RR_IsBattle() && radioracers_usehudfeed && cv_hudfeed_enabled.value;
 }
 
+static const char* filterPlayerName(player_t* p) {
+    if (IsPlayerMuted(p-players))
+        return "???";
+    return player_names[p-players];
+}
+
 // Push a player interaction to the feed.
 void RR_PushPlayerDamageToFeed(mobj_t *source, mobj_t *target, mobj_t *inflictor) {
     if (!canUseHudfeed()) return;
@@ -687,8 +694,8 @@ void RR_PushPlayerDamageToFeed(mobj_t *source, mobj_t *target, mobj_t *inflictor
     player_t* source_plyr = source->player;
     player_t* target_plyr = target->player;
 
-    std::string attacker = player_names[source_plyr-players];
-    std::string victim = player_names[target_plyr-players];
+    std::string attacker = filterPlayerName(source_plyr);
+    std::string victim = filterPlayerName(target_plyr);
 
     // Cap off player names if they're too long
     // (maybe?)
@@ -720,8 +727,8 @@ void RR_PushPlayerDeathToFeed(mobj_t *source, mobj_t *target, mobj_t *inflictor)
     player_t* source_plyr = source->player;
     player_t* target_plyr = target->player;
 
-    std::string attacker = player_names[source_plyr-players];
-    std::string victim = player_names[target_plyr-players];
+    std::string attacker = filterPlayerName(source_plyr);
+    std::string victim = filterPlayerName(target_plyr);
 
     const boolean self_hit = source_plyr == target_plyr;
     
@@ -752,8 +759,8 @@ void RR_PushPlayerInteractionToFeed(mobj_t *source, mobj_t *target, playerattack
     player_t* source_plyr = source->player;
     player_t* target_plyr = target->player;
 
-    std::string attacker = player_names[source_plyr-players];
-    std::string victim = player_names[target_plyr-players];
+    std::string attacker = filterPlayerName(source_plyr);
+    std::string victim = filterPlayerName(target_plyr);
 
     // Cap off player names if they're too long
     // (maybe?)
@@ -778,7 +785,7 @@ void RR_PushGlobalEventToFeed(player_t* player, globalfeedevent_t event) {
     ItemConfigForFeedUpdate itemConfig = getItemConfigForGlobalFeedUpdate(event);
     if (itemConfig.patch.empty()) return;
     
-    const std::string player_name = player_names[player-players];
+    const std::string player_name = filterPlayerName(player);
 
     // Push to the feed
     hudfeed.push(std::make_unique<GlobalFeedUpdate>(player_name, itemConfig));
@@ -804,7 +811,7 @@ void RR_PushGlobalGradeEventToFeed(player_t* player, gp_rank_e rank, boolean per
         .rainbow = (showSRanks)
     };
         
-    const std::string player_name = player_names[player-players];
+    const std::string player_name = filterPlayerName(player);
 
     // Push to the feed
     hudfeed.push(std::make_unique<GlobalPlayerFeedUpdate>(
@@ -837,7 +844,7 @@ void RR_PushGlobalFaultEventToFeed(player_t* player) {
 
     // Push to the feed
     hudfeed.push(std::make_unique<GlobalPlayerFeedUpdate>(
-        player_names[player-players], 
+        filterPlayerName(player),
         faultConfig,
         stplyr == player
     ));

--- a/src/radioracers/hud/rr_hud.cpp
+++ b/src/radioracers/hud/rr_hud.cpp
@@ -28,6 +28,7 @@
 #include "../../k_color.h" // K_RainbowColor
 #include "../../z_zone.h" // Z_Realloc
 #include "../../i_time.h"
+#include "../../d_netcmd.h"
 
 #include "../../v_draw.hpp" // srb2:Draw
 
@@ -366,6 +367,10 @@ void RR_addPlayerToFinshTicker(player_t *player)
         return std::to_string(position) + "th";
     };
 
+    const char* player_name = player_names[player-players];
+    if (IsPlayerMuted(player-players))
+        player_name = "???";
+    
     /**
      * TODO: 
      *  * Handle player ties
@@ -373,7 +378,7 @@ void RR_addPlayerToFinshTicker(player_t *player)
      */
     playerFinishTickerQueue.push_back(
         {
-            M_GetText(va("%s \x86%s", position_string(player->position).c_str(), player_names[player-players])),
+            M_GetText(va("%s \x86%s", position_string(player->position).c_str(), player_name)),
             P_IsMachineLocalPlayer(player),
             offscreen_right_offset() // Start just off-screen to the right
         }

--- a/src/radioracers/rr_util.h
+++ b/src/radioracers/rr_util.h
@@ -27,6 +27,7 @@ extern void RR_HandleBlueSphereRumble(player_t *player);
 extern void RR_AnnounceBattleWinner(player_t *player, battle_win_type_t type);
 extern void RR_PlayCountdownJingle(INT16 timer, player_t *player);
 extern boolean RR_IsBattle(void);
+extern boolean RR_IsPlayerMutedForRndr(mobj_t* mo);
 extern boolean RR_ShouldGhostRing(mobj_t *mo);
 extern boolean RR_ShouldGhostRingboxes(mobj_t *mo);
 extern boolean RR_ShouldGhostItemCapsuleParts(mobj_t* mo);

--- a/src/radioracers/util/rr_util.c
+++ b/src/radioracers/util/rr_util.c
@@ -22,6 +22,7 @@
 #include "../../k_hud.h"
 #include "../../r_textures.h"
 #include "../../r_fps.h"
+#include "../../d_netcmd.h"
 
 boolean shouldApplyEncore(void)
 {
@@ -161,6 +162,13 @@ boolean RR_ShouldRecolorVoltage(mobj_t *mo)
 				&& mo->target->player == stplyr;
 
     return cv_obvious_voltage.value && r_splitscreen == 0 && isVoltage && hasValidTarget;
+}
+
+boolean RR_IsPlayerMutedForRndr(mobj_t* mo)
+{
+    if (mo->player == NULL)
+        return false;
+    return IsPlayerMuted((mo->player - players));
 }
 
 INT32 RR_FetchAlternateTripwire(INT32 original_textnum)

--- a/src/y_inter.cpp
+++ b/src/y_inter.cpp
@@ -57,6 +57,7 @@
 #include "music.h"
 
 #include "radioracers/rr_cvar.h"
+#include "d_netcmd.h"
 
 #ifdef HWRENDER
 #include "hardware/hw_main.h"
@@ -392,10 +393,11 @@ static void Y_CalculateMatchData(UINT8 rankingsmode, void (*comparison)(INT32))
 
 				if (players[i].skin < numskins)
 				{
+					const boolean canShowSkin = R_CanShowSkinInDemo(players[i].skin) && !IsPlayerMuted(i);
 					snprintf(data.headerstring,
 						sizeof data.headerstring,
 						"%s",
-						R_CanShowSkinInDemo(players[i].skin) ? skins[players[i].skin].realname : "???");
+						canShowSkin ? skins[players[i].skin].realname : "???");
 				}
 
 				data.showroundnum = true;
@@ -562,9 +564,9 @@ void Y_PlayerStandingsDrawer(y_data_t *standings, INT32 xoffset)
 		else
 		{
 			UINT8 *charcolormap = NULL;
-			if (!R_CanShowSkinInDemo(standings->character[i]))
+			if (!R_CanShowSkinInDemo(standings->character[i]) || IsPlayerMuted(pnum))
 			{
-				charcolormap = R_GetTranslationColormap(TC_BLINK, static_cast<skincolornum_t>(standings->color[i]), GTC_CACHE);
+				charcolormap = R_GetTranslationColormap(TC_BLINK, SKINCOLOR_GREY, GTC_CACHE);
 			}
 			else if (standings->color[i] != SKINCOLOR_NONE)
 			{
@@ -655,20 +657,23 @@ void Y_PlayerStandingsDrawer(y_data_t *standings, INT32 xoffset)
 				{
 					charcolormap = R_GetTranslationColormap(standings->character[i], static_cast<skincolornum_t>(standings->color[i]), GTC_CACHE);
 					
+					const boolean canShowSkin = R_CanShowSkinInDemo(standings->character[i]) && !IsPlayerMuted(pnum);
+					const UINT8* mutedcolormap = R_GetTranslationColormap(TC_RAINBOW, SKINCOLOR_GREY, GTC_CACHE);
+
 					if (cv_hud_usehighresportraits.value) {
 						V_DrawFixedPatch(
 							(x+14) << FRACBITS, (y-4) << FRACBITS,
 							(3*FRACUNIT)/4,
 							0,
-							R_CanShowSkinInDemo(standings->character[i]) ?
+							canShowSkin ?
 							faceprefix[standings->character[i]][FACE_RANK] : kp_unknownminimap,
-							charcolormap
+							canShowSkin ? charcolormap : mutedcolormap
 						);
 					} else {
 						V_DrawMappedPatch(x+14, y-5, 0,
-							R_CanShowSkinInDemo(standings->character[i]) ?
+							canShowSkin ?
 							faceprefix[standings->character[i]][FACE_MINIMAP] : kp_unknownminimap,
-							charcolormap); 
+							canShowSkin ? charcolormap : mutedcolormap); 
 					}
 
 				}
@@ -712,7 +717,7 @@ void Y_PlayerStandingsDrawer(y_data_t *standings, INT32 xoffset)
 						? hilicol
 						: 0
 				),
-				player_names[pnum]
+				IsPlayerMuted(pnum) ? "???" : player_names[pnum]
 			);
 
 			V_DrawRightAlignedThinString(


### PR DESCRIPTION
https://github.com/user-attachments/assets/57775589-004b-4860-8dca-6a4c685cae50

<img width="1314" height="433" alt="ringracers_feature_mute-players-enhance_UzvRQRZFy0" src="https://github.com/user-attachments/assets/9b80ace0-fb30-4c96-bca7-a6f0092603c1" />

----
If a player has muted another player, it will be visible in the following locations:

* In-game
  - The player sprite/model will use the same gray masking effect for characters that are not unlocked.
  - The player name will be replaced "???" in the nametag

* HUD
  - The player faceranking icon will be replaced with a generic placeholder
  - The player name will be replaced with "???" in the chat, finish ticker, spectator ticker, intermission screen, and hudfeed

The placeholder graphic for facerankings _could_ be replaced with a question mark graphic (like SRB2Kart), but the current solution is fine.