### PR TITLE
Widescreen support (up to 2K)

### DIFF
--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -546,6 +546,13 @@ consvar_t cv_obvious_voltage = Player("obviousvoltage", "On").on_off();
 // Draw any danger checks on the side of the HUD
 consvar_t cv_show_dangerous_player_check = Player("showdangerplayercheck", "Off").on_off();
 
+// HUD Scaling
+consvar_t cv_highreshudscale = Player("highreshudscale", "1")
+	.floating_point()
+	.min_max(4*FRACUNIT/5, (6*FRACUNIT/5))
+	.step_amount(FRACUNIT)
+	.onchange_noinit(SCR_Recalc);
+
 // Item timers (not all)
 consvar_t cv_gingeritemtimers = Player("huditemtimers", "On").on_off();
 consvar_t cv_gingeritemtimersbiggertext = Player("huditemtimerssize", "Default").values({

--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -547,11 +547,14 @@ consvar_t cv_obvious_voltage = Player("obviousvoltage", "On").on_off();
 consvar_t cv_show_dangerous_player_check = Player("showdangerplayercheck", "Off").on_off();
 
 // HUD Scaling
-consvar_t cv_highreshudscale = Player("highreshudscale", "1")
-	.floating_point()
-	.min_max(4*FRACUNIT/5, (6*FRACUNIT/5))
-	.step_amount(FRACUNIT)
+consvar_t cv_highreshudscale = Player("highreshudscale", "Default")
+	.values({
+		{FRACUNIT, "Default"}, 
+		{6*FRACUNIT/5, "120%"}, 
+		{0, NULL}
+	})
 	.onchange_noinit(SCR_Recalc);
+consvar_t cv_highreshudscale_temp = MenuDummy("highreshudscale_temp", "");
 
 // Item timers (not all)
 consvar_t cv_gingeritemtimers = Player("huditemtimers", "On").on_off();

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -1560,6 +1560,26 @@ void K_DrawMapThumbnail2(fixed_t x, fixed_t y, fixed_t width, UINT32 flags, UINT
 	K_DrawLikeMapThumbnail(x, y, width, flags, PictureOfLevel, colormap, accordion);
 }
 
+void K_DrawMapThumbnail2Widescreen(fixed_t x, fixed_t y, fixed_t width, UINT32 flags, UINT16 map, const UINT8 *colormap, fixed_t accordion)
+{
+	patch_t *PictureOfLevel = NULL;
+
+	if (map >= nummapheaders || !mapheaderinfo[map])
+	{
+		PictureOfLevel = nolvl;
+	}
+	else if (!mapheaderinfo[map]->thumbnailPic)
+	{
+		PictureOfLevel = blanklvl;
+	}
+	else
+	{
+		PictureOfLevel = static_cast<patch_t*>(mapheaderinfo[map]->thumbnailPic);
+	}
+
+	K_DrawLikeMapThumbnailWidescreen(x, y, width, flags, PictureOfLevel, colormap, accordion);
+}
+
 void K_DrawLikeMapThumbnail(fixed_t x, fixed_t y, fixed_t width, UINT32 flags, patch_t *patch, const UINT8 *colormap, fixed_t accordion)
 {
 	fixed_t scale = FixedDiv(width, (320 << FRACBITS));
@@ -1575,6 +1595,14 @@ void K_DrawLikeMapThumbnail(fixed_t x, fixed_t y, fixed_t width, UINT32 flags, p
 		patch,
 		colormap
 	);
+}
+
+void K_DrawLikeMapThumbnailWidescreen(fixed_t x, fixed_t y, fixed_t width, UINT32 flags, patch_t *patch, const UINT8 *colormap, fixed_t accordion)
+{
+	if (flags & V_FLIP)
+		x += FixedMul(width, accordion);
+
+	V_DrawAdaptiveScaledFullScreenPatch(patch, const_cast<uint8_t*>(colormap), flags|V_NOSCALEPATCH);
 }
 
 void K_DrawMapAsFace(INT32 x, INT32 y, UINT32 flags, UINT16 map, const UINT8 *colormap, fixed_t accordion, INT32 scalefactor)
@@ -5017,14 +5045,6 @@ static void K_drawRingCounter(boolean gametypeinfoshown)
 				}
 			}
 		}
-
-		INT32 hr = stplyr->hudrings;
-
-		if (stplyr->baildrop)
-			hr += -1 * (stplyr->baildrop / BAIL_DROPFREQUENCY);
-
-		if (hr < -999)
-			hr = -999;
 
 		INT32 hr = stplyr->hudrings;
 

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -2402,8 +2402,10 @@ static void K_drawBackupItem(void)
 	boolean drawingOnPlayer = (cv_rouletteonplayer.value == 1 && r_splitscreen == 0);
 	const fixed_t baseHudScaleFixed = (drawingOnPlayer) ? RR_getItemBoxHudScale() : FRACUNIT;
 	const float_t baseHudScaleFloat = RR_getItemBoxHudScaleFloat();
+	INT32 backupitemflags = transflag|V_SLIDEIN;
+	
 	if (drawingOnPlayer) {
-		transflag = V_20TRANS;
+		backupitemflags = V_20TRANS;
 		fx = itemRouletteX + ((int)(30 * baseHudScaleFloat));
 		fy = itemRouletteY - ((int)(10 * baseHudScaleFloat));
 		tx = (int)(25 * baseHudScaleFloat);
@@ -2425,7 +2427,7 @@ static void K_drawBackupItem(void)
 
 		V_DrawFixedPatch(
 			fx<<FRACBITS, (fy<<FRACBITS),
-			baseHudScaleFixed, transflag|V_SLIDEIN|fflags,
+			baseHudScaleFixed, backupitemflags,
 			localpatch[1], (localcolor[1] ? R_GetTranslationColormap(colormode[1], localcolor[1], GTC_CACHE) : NULL)
 		);
 
@@ -2433,17 +2435,17 @@ static void K_drawBackupItem(void)
 			V_DrawStringScaled(
 				(fx+tx)<<FRACBITS, (fy+ty)<<FRACBITS,
 				baseHudScaleFixed, baseHudScaleFixed, baseHudScaleFixed,
-				transflag|V_SLIDEIN|fflags, NULL, TINY_FONT, va("x%d", stplyr->backupitemamount)
+				backupitemflags, NULL, TINY_FONT, va("x%d", stplyr->backupitemamount)
 			);
 		} else {
-			V_DrawString(fx+tx, fy+ty, V_HUDTRANS|V_SLIDEIN|fflags, va("x%d", stplyr->backupitemamount));
+			V_DrawString(fx+tx, fy+ty, backupitemflags, va("x%d", stplyr->backupitemamount));
 		}
 	}
 	else
 	{
 		V_DrawFixedPatch(
 			fx<<FRACBITS, (fy<<FRACBITS),
-			baseHudScaleFixed, transflag|V_SLIDEIN|fflags,
+			baseHudScaleFixed, backupitemflags,
 			localpatch[1], (localcolor[1] ? R_GetTranslationColormap(colormode[1], localcolor[1], GTC_CACHE) : NULL)
 		);
 	}

--- a/src/k_hud.h
+++ b/src/k_hud.h
@@ -61,7 +61,13 @@ void K_drawKart2PTimestamp(void);
 void K_drawKart4PTimestamp(void);
 void K_drawEmeraldWin(boolean overlay);
 void K_DrawMapThumbnail2(fixed_t x, fixed_t y, fixed_t width, UINT32 flags, UINT16 map, const UINT8 *colormap, fixed_t accordion);
+
+// For widescreen
+void K_DrawMapThumbnail2Widescreen(fixed_t x, fixed_t y, fixed_t width, UINT32 flags, UINT16 map, const UINT8 *colormap, fixed_t accordion);
+void K_DrawLikeMapThumbnailWidescreen(fixed_t x, fixed_t y, fixed_t width, UINT32 flags, patch_t *patch, const UINT8 *colormap, fixed_t accordion);
+
 #define K_DrawMapThumbnail(x, y, w, f, m, c) K_DrawMapThumbnail2(x, y, w, f, m, c, FRACUNIT)
+#define K_DrawMapThumbnailWidescreen(x, y, w, f, m, c) K_DrawMapThumbnail2Widescreen(x, y, w, f, m, c, FRACUNIT)
 void K_DrawLikeMapThumbnail(fixed_t x, fixed_t y, fixed_t width, UINT32 flags, patch_t *patch, const UINT8 *colormap, fixed_t accordion);
 void K_DrawMapAsFace(INT32 x, INT32 y, UINT32 flags, UINT16 map, const UINT8 *colormap, fixed_t accordion, INT32 unit);
 void K_drawTargetHUD(const vector3_t *origin, player_t *player);

--- a/src/k_menudraw.c
+++ b/src/k_menudraw.c
@@ -94,6 +94,7 @@ int	snprintf(char *str, size_t n, const char *fmt, ...);
 
 // Radio
 #include "d_clisrv.h"
+#include "radioracers/rr_cvar.h"
 
 fixed_t M_TimeFrac(tic_t tics, tic_t duration)
 {
@@ -516,7 +517,9 @@ void M_DrawMenuForeground(void)
 		((vid.width % BASEVIDWIDTH != 0) || (vid.height % BASEVIDHEIGHT != 0)))
 	{
 		// Radio: What if...
-		// V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName("WEIRDRES", PU_CACHE), NULL);
+		// Egg TV workaround
+		if (cv_highreshudscale_temp.value != 0)
+			V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName("WEIRDRES", PU_CACHE), NULL);
 	}
 }
 

--- a/src/k_menudraw.c
+++ b/src/k_menudraw.c
@@ -364,7 +364,12 @@ void M_DrawMenuBackground(void)
 void M_DrawExtrasBack(void)
 {
 	patch_t *bg = W_CachePatchName("M_XTRABG", PU_CACHE);
-	V_DrawFixedPatch(0, 0, FRACUNIT, 0, bg, NULL);
+
+	if (IS_WEIRD_RES()) {
+		V_DrawAdaptiveScaledFullScreenPatch(bg, NULL, V_NOSCALEPATCH);
+	} else {
+		V_DrawFixedPatch(0, 0, FRACUNIT, 0, bg, NULL);
+	}
 }
 
 UINT16 M_GetCvPlayerColor(UINT8 pnum)
@@ -397,6 +402,8 @@ static void M_DrawMenuParty(void)
 	UINT16 color;
 	UINT8 *colormap;
 
+	const INT32 partyflags = IS_WEIRD_RES() ? V_SNAPTOBOTTOM|V_SNAPTOLEFT : 0;
+
 	if (setup_numplayers == 0 || currentMenu == &PLAY_CharSelectDef || currentMenu == &OPTIONS_GameplayItemsDef || currentMenu == &MISC_ChallengesDef)
 	{
 		return;
@@ -422,66 +429,66 @@ static void M_DrawMenuParty(void)
 		case 1:
 		{
 			x -= 8;
-			V_DrawScaledPatch(x, y, 0, small);
+			V_DrawScaledPatch(x, y, partyflags, small);
 
 			grab_skin_and_colormap(0);
 
-			V_DrawMappedPatch(x + 22, y + 8, 0, faceprefix[skin][FACE_MINIMAP], colormap);
+			V_DrawMappedPatch(x + 22, y + 8, partyflags, faceprefix[skin][FACE_MINIMAP], colormap);
 			break;
 		}
 		case 2:
 		{
 			x -= 8;
 			V_DrawScaledPatch(x, y, 0, small);
-			V_DrawScaledPatch(x + PLATTER_OFFSET, y - PLATTER_STAGGER, 0, small);
+			V_DrawScaledPatch(x + PLATTER_OFFSET, y - PLATTER_STAGGER, partyflags, small);
 
 			grab_skin_and_colormap(1);
 
-			V_DrawMappedPatch(x + PLATTER_OFFSET + 22, y - PLATTER_STAGGER + 8, 0, faceprefix[skin][FACE_MINIMAP], colormap);
+			V_DrawMappedPatch(x + PLATTER_OFFSET + 22, y - PLATTER_STAGGER + 8, partyflags, faceprefix[skin][FACE_MINIMAP], colormap);
 
 			grab_skin_and_colormap(0);
 
-			V_DrawMappedPatch(x + 22, y + 8, 0, faceprefix[skin][FACE_MINIMAP], colormap);
+			V_DrawMappedPatch(x + 22, y + 8, partyflags, faceprefix[skin][FACE_MINIMAP], colormap);
 			break;
 		}
 		case 3:
 		{
 			V_DrawScaledPatch(x, y, 0, large);
-			V_DrawScaledPatch(x + PLATTER_OFFSET, y - PLATTER_STAGGER, 0, small);
+			V_DrawScaledPatch(x + PLATTER_OFFSET, y - PLATTER_STAGGER, partyflags, small);
 
 			grab_skin_and_colormap(1);
 
-			V_DrawMappedPatch(x + PLATTER_OFFSET + 22, y - PLATTER_STAGGER + 8, 0, faceprefix[skin][FACE_MINIMAP], colormap);
+			V_DrawMappedPatch(x + PLATTER_OFFSET + 22, y - PLATTER_STAGGER + 8, partyflags, faceprefix[skin][FACE_MINIMAP], colormap);
 
 			grab_skin_and_colormap(0);
 
-			V_DrawMappedPatch(x + 12, y - 2, 0, faceprefix[skin][FACE_MINIMAP], colormap);
+			V_DrawMappedPatch(x + 12, y - 2, partyflags, faceprefix[skin][FACE_MINIMAP], colormap);
 
 			grab_skin_and_colormap(2);
 
-			V_DrawMappedPatch(x + 22, y + 8, 0, faceprefix[skin][FACE_MINIMAP], colormap);
+			V_DrawMappedPatch(x + 22, y + 8, partyflags, faceprefix[skin][FACE_MINIMAP], colormap);
 			break;
 		}
 		case 4:
 		{
 			V_DrawScaledPatch(x, y, 0, large);
-			V_DrawScaledPatch(x + PLATTER_OFFSET, y - PLATTER_STAGGER, 0, large);
+			V_DrawScaledPatch(x + PLATTER_OFFSET, y - PLATTER_STAGGER, partyflags, large);
 
 			grab_skin_and_colormap(1);
 
-			V_DrawMappedPatch(x + PLATTER_OFFSET + 12, y - PLATTER_STAGGER - 2, 0, faceprefix[skin][FACE_MINIMAP], colormap);
+			V_DrawMappedPatch(x + PLATTER_OFFSET + 12, y - PLATTER_STAGGER - 2, partyflags, faceprefix[skin][FACE_MINIMAP], colormap);
 
 			grab_skin_and_colormap(0);
 
-			V_DrawMappedPatch(x + 12, y - 2, 0, faceprefix[skin][FACE_MINIMAP], colormap);
+			V_DrawMappedPatch(x + 12, y - 2, partyflags, faceprefix[skin][FACE_MINIMAP], colormap);
 
 			grab_skin_and_colormap(3);
 
-			V_DrawMappedPatch(x + PLATTER_OFFSET + 22, y - PLATTER_STAGGER + 8, 0, faceprefix[skin][FACE_MINIMAP], colormap);
+			V_DrawMappedPatch(x + PLATTER_OFFSET + 22, y - PLATTER_STAGGER + 8, partyflags, faceprefix[skin][FACE_MINIMAP], colormap);
 
 			grab_skin_and_colormap(2);
 
-			V_DrawMappedPatch(x + 22, y + 8, 0, faceprefix[skin][FACE_MINIMAP], colormap);
+			V_DrawMappedPatch(x + 22, y + 8, partyflags, faceprefix[skin][FACE_MINIMAP], colormap);
 			break;
 		}
 		default:
@@ -494,7 +501,7 @@ static void M_DrawMenuParty(void)
 
 	x += PLATTER_WIDTH;
 	y += small->height;
-	V_DrawScaledPatch(x + 16, y - 12, 0, W_CachePatchName(va("OPPRNK0%d", setup_numplayers % 10), PU_CACHE));
+	V_DrawScaledPatch(x + 16, y - 12, partyflags, W_CachePatchName(va("OPPRNK0%d", setup_numplayers % 10), PU_CACHE));
 }
 
 void M_DrawMenuForeground(void)
@@ -817,7 +824,7 @@ static void M_DrawPauseRoundQueue(INT16 offset, boolean canqueue)
 		standings.showrank = true;
 	}
 
-	Y_RoundQueueDrawer(&standings, offset, false, false, canqueue);
+	Y_RoundQueueDrawer(&standings, offset, false, IS_WEIRD_RES(), canqueue);
 }
 
 // Draw the message popup submenu
@@ -952,6 +959,8 @@ static void M_DrawPausedText(INT32 x)
 	patch_t *pausetext = W_CachePatchName("M_PAUSET", PU_CACHE);
 
 	INT32 snapFlags = menuactive ? 0 : (V_SNAPTOLEFT|V_SNAPTOTOP);
+	if (menuactive && IS_WEIRD_RES())
+		snapFlags = (V_SNAPTOLEFT|V_SNAPTOTOP);
 
 	V_DrawFixedPatch(x, -5*FRACUNIT, FRACUNIT, snapFlags|V_ADD, pausebg,   NULL);
 	V_DrawFixedPatch(x, -5*FRACUNIT, FRACUNIT, snapFlags,       pausetext, NULL);
@@ -1146,9 +1155,9 @@ void M_DrawGenericMenu(void)
 					cursory = y;
 
 				if ((currentMenu->menuitems[i].status & IT_DISPLAY)==IT_STRING)
-					V_DrawMenuString(x, y, 0, currentMenu->menuitems[i].text);
+					V_DrawMenuString(x, y, V_SNAPTOTOP, currentMenu->menuitems[i].text);
 				else
-					V_DrawMenuString(x, y, highlightflags, currentMenu->menuitems[i].text);
+					V_DrawMenuString(x, y, highlightflags|V_SNAPTOTOP, currentMenu->menuitems[i].text);
 
 				// Cvar specific handling
 				switch (currentMenu->menuitems[i].status & IT_TYPE)
@@ -1183,13 +1192,13 @@ void M_DrawGenericMenu(void)
 							default:
 								w = V_MenuStringWidth(cv->string, 0);
 								V_DrawMenuString(BASEVIDWIDTH - x - w, y,
-									((cv->flags & CV_CHEAT) && !CV_IsSetToDefault(cv) ? warningflags : highlightflags), cv->string);
+									((cv->flags & CV_CHEAT) && !CV_IsSetToDefault(cv) ? warningflags|V_SNAPTOTOP : highlightflags|V_SNAPTOTOP), cv->string);
 								if (i == itemOn)
 								{
 									V_DrawMenuString(BASEVIDWIDTH - x - 10 - w - (skullAnimCounter/5), y,
-											highlightflags, "\x1C"); // left arrow
+											highlightflags|V_SNAPTOTOP, "\x1C"); // left arrow
 									V_DrawMenuString(BASEVIDWIDTH - x + 2 + (skullAnimCounter/5), y,
-											highlightflags, "\x1D"); // right arrow
+											highlightflags|V_SNAPTOTOP, "\x1D"); // right arrow
 								}
 								break;
 						}
@@ -1241,14 +1250,14 @@ void M_DrawGenericMenu(void)
 	if (((currentMenu->menuitems[itemOn].status & IT_DISPLAY) == IT_PATCH)
 		|| ((currentMenu->menuitems[itemOn].status & IT_DISPLAY) == IT_NOTHING))
 	{
-		V_DrawScaledPatch(currentMenu->x + SKULLXOFF, cursory - 5, 0,
+		V_DrawScaledPatch(currentMenu->x + SKULLXOFF, cursory - 5, V_SNAPTOTOP,
 			W_CachePatchName("M_CURSOR", PU_CACHE));
 	}
 	else
 	{
-		V_DrawScaledPatch(currentMenu->x - 24, cursory, 0,
+		V_DrawScaledPatch(currentMenu->x - 24, cursory, V_SNAPTOTOP,
 			W_CachePatchName("M_CURSOR", PU_CACHE));
-		V_DrawMenuString(currentMenu->x, cursory, highlightflags, currentMenu->menuitems[itemOn].text);
+		V_DrawMenuString(currentMenu->x, cursory, highlightflags|V_SNAPTOTOP, currentMenu->menuitems[itemOn].text);
 	}
 }
 
@@ -2899,6 +2908,12 @@ static void M_DrawCupPreview(INT16 y, levelsearch_t *baselevelsearch)
 
 	patch_t *staticpat = unvisitedlvl[cupgrid.previewanim % 4];
 
+	INT32 bufferspace = 0;
+	if (IS_WEIRD_RES()) {
+		// Many, many thanks to Toaster. (Y_RoundQueueDrawer)
+		bufferspace = ((vid.width/vid.dupx) - BASEVIDWIDTH) / 2;
+	}
+
 	if (baselevelsearch->cup && maxlevels > 0)
 	{
 		unsignedportion = (cupgrid.previewanim % (maxlevels * ustep));
@@ -2918,8 +2933,8 @@ static void M_DrawCupPreview(INT16 y, levelsearch_t *baselevelsearch)
 			add--;
 		}
 
-		x = -(x % fracstep);
-		while (x < BASEVIDWIDTH * FRACUNIT)
+		x = -(x % (fracstep)) - (bufferspace * FRACUNIT);
+		while (x < (BASEVIDWIDTH + bufferspace) * FRACUNIT)
 		{
 			if (map >= nummapheaders)
 			{
@@ -2946,7 +2961,7 @@ static void M_DrawCupPreview(INT16 y, levelsearch_t *baselevelsearch)
 					NULL);
 			}
 
-			x += fracstep;
+			x += (fracstep);
 
 			map = M_GetNextLevelInList(map, &i, &locklesslevelsearch);
 		}
@@ -2956,8 +2971,8 @@ static void M_DrawCupPreview(INT16 y, levelsearch_t *baselevelsearch)
 		unsignedportion = (cupgrid.previewanim % ustep);
 		x = (unsignedportion * FRACUNIT) + rendertimefrac_unpaused;
 
-		x = -(x % fracstep);
-		while (x < BASEVIDWIDTH * FRACUNIT)
+		x = -(x % (fracstep)) - (bufferspace * FRACUNIT);
+		while (x < (BASEVIDWIDTH + bufferspace) * FRACUNIT)
 		{
 			V_DrawFixedPatch(x + FRACUNIT, (y+2) * FRACUNIT, FRACUNIT, 0, staticpat, NULL);
 			x += fracstep;
@@ -3425,6 +3440,13 @@ void M_DrawCupSelect(void)
 	INT16 ty = M_EaseWithTransition(Easing_Linear, 5 * 24);
 	y = 146 + ty;
 	V_DrawFill(0, y, BASEVIDWIDTH, 54, 31);
+
+	if (IS_WEIRD_RES()) {
+		// Draw some black rectangles to fill in the buffer space
+		const INT32 bufferspace = ((vid.width/vid.dupx) - BASEVIDWIDTH) / 2;
+		V_DrawFill(-bufferspace, y-20, bufferspace, 74, 31);
+		V_DrawFill(BASEVIDWIDTH, y-20, bufferspace, 74, 31);
+	}
 	M_DrawCupPreview(y, &templevelsearch);
 
 	M_DrawCupTitle(120 - ty, &templevelsearch);
@@ -3907,13 +3929,21 @@ void M_DrawSealedBack(void)
 			return;
 	}
 
-	V_DrawFixedPatch(
-		0, 0,
-		FRACUNIT,
-		translucencylevel << V_ALPHASHIFT,
-		W_CachePatchName("MENUI008", PU_CACHE),
-		R_GetTranslationColormap(TC_RAINBOW, SKINCOLOR_BLACK, GTC_CACHE)
-	);
+	if (IS_WEIRD_RES()) {
+		V_DrawAdaptiveScaledFullScreenPatch(
+			W_CachePatchName("MENUI008", PU_CACHE), 
+			R_GetTranslationColormap(TC_RAINBOW, SKINCOLOR_BLACK, GTC_CACHE), 
+			(translucencylevel << V_ALPHASHIFT)|V_NOSCALEPATCH
+		);
+	} else {
+		V_DrawFixedPatch(
+			0, 0,
+			FRACUNIT,
+			translucencylevel << V_ALPHASHIFT,
+			W_CachePatchName("MENUI008", PU_CACHE),
+			R_GetTranslationColormap(TC_RAINBOW, SKINCOLOR_BLACK, GTC_CACHE)
+		);
+	}
 }
 
 void M_DrawTimeAttack(void)
@@ -4154,6 +4184,7 @@ void M_DrawMasterServerReminder(void)
 	// Did you change the Server Browser address? Have a little reminder.
 
 	INT32 mservflags = 0;
+	INT32 mservfadeflags = 0;
 	if (CV_IsSetToDefault(&cv_masterserver))
 		mservflags = highlightflags;
 	else
@@ -4161,7 +4192,12 @@ void M_DrawMasterServerReminder(void)
 
 	INT32 y = BASEVIDHEIGHT - 10;
 
-	V_DrawFadeFill(0, y-1, BASEVIDWIDTH, 10+1, 0, 31, 5);
+	if (IS_WEIRD_RES()) {
+		mservflags |= V_SNAPTOBOTTOM;
+		mservfadeflags = V_SNAPTOBOTTOM;
+	}
+
+	V_DrawFadeFill(0, y-1, BASEVIDWIDTH, 10+1, mservfadeflags, 31, 5);
 	V_DrawCenteredThinString(BASEVIDWIDTH/2, y,
 		mservflags, va("List via \"%s\"", cv_masterserver.string));
 }
@@ -4466,9 +4502,13 @@ void M_DrawMPRoomSelect(void)
 		colormap_r = R_GetTranslationColormap(TC_RAINBOW, SKINCOLOR_GREY, GTC_CACHE);
 
 	// Draw the 2 sides of the background
-	V_DrawFixedPatch(0, 0, FRACUNIT, 0, bg_l, colormap_l);
-	V_DrawFixedPatch(0, 0, FRACUNIT, 0, bg_r, colormap_r);
-
+	if (IS_WEIRD_RES()) {
+		V_DrawAdaptiveScaledFullScreenPatch(bg_l, colormap_l, V_NOSCALEPATCH);
+		V_DrawAdaptiveScaledFullScreenPatch(bg_r, colormap_r, V_NOSCALEPATCH);
+	} else {
+		V_DrawFixedPatch(0, 0, FRACUNIT, 0, bg_l, colormap_l);
+		V_DrawFixedPatch(0, 0, FRACUNIT, 0, bg_r, colormap_r);
+	}
 
 	// Draw the black split:
 	V_DrawFixedPatch(160<<FRACBITS, 0, FRACUNIT, 0, split, NULL);
@@ -4482,16 +4522,19 @@ void M_DrawMPRoomSelect(void)
 
 
 	// Draw buttons:
+	INT32 menuhintflags = 0;
+	if (IS_WEIRD_RES())
+		menuhintflags = V_SNAPTOTOP;
 
 	V_DrawFixedPatch(160<<FRACBITS, 90<<FRACBITS, FRACUNIT, mpmenu.room ? (5<<V_ALPHASHIFT) : 0, butt1[(mpmenu.room) ? 1 : 0], NULL);
 
 	V_DrawFixedPatch(160<<FRACBITS, 90<<FRACBITS, FRACUNIT, (!mpmenu.room) ? (5<<V_ALPHASHIFT) : 0, butt2[(!mpmenu.room) ? 1 : 0], NULL);
 
-	V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName("MENUHINT", PU_CACHE), NULL);
+	V_DrawFixedPatch(0, 0, FRACUNIT, menuhintflags, W_CachePatchName("MENUHINT", PU_CACHE), NULL);
 
-	V_DrawCenteredMenuString(BASEVIDWIDTH/2, 24, 0, "\xA3  Select a Room  \xA2");
+	V_DrawCenteredMenuString(BASEVIDWIDTH/2, 24, menuhintflags, "\xA3  Select a Room  \xA2");
 
-	V_DrawCenteredThinString(BASEVIDWIDTH/2, 12, 0, (mpmenu.room) ? "Play with community maps, characters, and gametypes. (Expect additional downloads!)" : "Jump into a standard game of Ring Racers.");
+	V_DrawCenteredThinString(BASEVIDWIDTH/2, 12, menuhintflags, (mpmenu.room) ? "Play with community maps, characters, and gametypes. (Expect additional downloads!)" : "Jump into a standard game of Ring Racers.");
 
 	M_DrawMasterServerReminder();
 }
@@ -4539,7 +4582,7 @@ static void M_DrawServerCountAndHorizontalBar(void)
 		V_DrawRightAlignedMenuString(
 			BASEVIDWIDTH - currentMenu->x,
 			y,
-			highlightflags,
+			highlightflags|V_SNAPTOTOP,
 			text
 		);
 	}
@@ -4547,13 +4590,13 @@ static void M_DrawServerCountAndHorizontalBar(void)
 	{
 		V_DrawRightAlignedMenuString(
 			BASEVIDWIDTH - currentMenu->x - 12, y,
-			highlightflags,
+			highlightflags|V_SNAPTOTOP,
 			text
 		);
 
 		V_DrawCenteredString( // Only clean way to center the throbber without exposing character width
 			BASEVIDWIDTH - currentMenu->x - 4, y,
-			highlightflags,
+			highlightflags|V_SNAPTOTOP,
 			va("%c", throbber[throbindex])
 		);
 	}
@@ -4612,7 +4655,11 @@ void M_DrawMPServerBrowser(void)
 	INT32 ypos = 0;
 
 	// background stuff
-	V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName(header[mode][1], PU_CACHE), NULL);
+	if (IS_WEIRD_RES()) {
+		V_DrawAdaptiveScaledFullScreenPatch(W_CachePatchName(header[mode][1], PU_CACHE), NULL, V_NOSCALEPATCH);
+	} else {
+		V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName(header[mode][1], PU_CACHE), NULL);
+	}
 
 	V_DrawFixedPatch(0, (BASEVIDHEIGHT + 16) * FRACUNIT, FRACUNIT, V_TRANSLUCENT, W_CachePatchName("MENUBG2", PU_CACHE), NULL);
 
@@ -4649,6 +4696,9 @@ void M_DrawMPServerBrowser(void)
 		if (transflag >= 0 && transflag < 10)
 		{
 			transflag = transflag << V_ALPHASHIFT;	// shift the translucency flag.
+
+			if (IS_WEIRD_RES())
+				transflag |= V_SNAPTOTOP;
 
 			if (serverlist[i].cachedgtcalc < 3)
 			{
@@ -4805,18 +4855,22 @@ void M_DrawMPServerBrowser(void)
 			// voice chat enabled
 			if (serverlist[i].info.kartvars & SV_VOICEENABLED)
 			{
-				V_DrawFixedPatch((startx - 3) * FRACUNIT, (starty + ypos + 2) * FRACUNIT, FRACUNIT, 0, voicepat, NULL);
+				V_DrawFixedPatch((startx - 3) * FRACUNIT, (starty + ypos + 2) * FRACUNIT, FRACUNIT, IS_WEIRD_RES() ? V_SNAPTOTOP : 0, voicepat, NULL);
 			}
 		}
 		ypos += SERVERSPACE;
 	}
 
 	// Draw genericmenu ontop!
-	V_DrawFill(0, 0, 320, 52, 31);
-	V_DrawFill(0, 53, 320, 1, 31);
-	V_DrawFill(0, 55, 320, 1, 31);
+	INT32 gamemodeflags = 0;
+	if (IS_WEIRD_RES()) 
+		gamemodeflags = V_SNAPTOTOP;
+	
+	V_DrawFill(0, 0, 320, 52, 31|gamemodeflags);
+	V_DrawFill(0, 53, 320, 1, 31|gamemodeflags);
+	V_DrawFill(0, 55, 320, 1, 31|gamemodeflags);
 
-	V_DrawCenteredGamemodeString(160, 2, 0, 0, header[mode][0]);
+	V_DrawCenteredGamemodeString(160, 2, gamemodeflags, 0, header[mode][0]);
 
 	// normal menu options
 	M_DrawGenericMenu();
@@ -6454,7 +6508,7 @@ void M_DrawPause(void)
 	}
 
 	// Vertical Strip:
-	V_DrawFixedPatch((230 + offset)<<FRACBITS, 0, FRACUNIT, V_ADD, vertbg, NULL);
+	V_DrawFixedPatch((230 + offset)<<FRACBITS, 0, FRACUNIT, V_ADD|(IS_WEIRD_RES() ? V_SNAPTOTOP : 0), vertbg, NULL);
 
 	// Okay that's cool but which icon do we draw first? let's roll back from itemOn!
 	// At most we'll draw 7 items, 1 in the center, 3 above, 3 below.
@@ -6697,6 +6751,7 @@ void M_DrawPause(void)
 
 	if (gamestate != GS_INTERMISSION && roundqueue.size > 0)
 	{
+		INT32 roundinfoflags = (IS_WEIRD_RES()) ? V_SNAPTOBOTTOM : 0;
 		if (roundqueue.position > 0 && roundqueue.position <= roundqueue.size)
 		{
 			patch_t *smallroundpatch = ST_getRoundPicture(true);
@@ -6705,13 +6760,13 @@ void M_DrawPause(void)
 			{
 				V_DrawMappedPatch(
 					24, 145 + offset/2,
-					0,
+					roundinfoflags,
 					smallroundpatch,
 					NULL);
 			}
 		}
 
-		V_DrawCenteredMenuString(24, 167 + offset/2, V_YELLOWMAP, M_GetGameplayMode());
+		V_DrawCenteredMenuString(24, 167 + offset/2, V_YELLOWMAP|roundinfoflags, M_GetGameplayMode());
 
 		drawqueue = true;
 	}
@@ -8640,6 +8695,7 @@ void M_DrawChallenges(void)
 	INT16 i, j;
 	const char *str;
 	INT16 offset;
+	INT32 bufferspace = IS_WEIRD_RES() ? ((vid.width/vid.dupx) - BASEVIDWIDTH) / 2 : 0;
 
 	{
 #define questionslow 4 // slows down the scroll by this factor
@@ -8652,19 +8708,36 @@ void M_DrawChallenges(void)
 		questionoffset_f = fmod(challengesmenu.ticker + FixedToFloat(rendertimefrac), questionloop);
 		questionoffset = floor(questionoffset_f);
 
-		// Background gradient
-		V_DrawFixedPatch(0, 0, FRACUNIT, 0, bg, NULL);
+		if(IS_WEIRD_RES()) {
+			V_DrawAdaptiveScaledFullScreenPatch(bg, NULL, V_NOSCALEPATCH);
+			V_DrawAdaptiveScaledPatchWithCoords(
+				-((160 + questionoffset)*FRACUNIT)/questionslow,
+				-(4*FRACUNIT) - (245*(FixedDiv((questionloop - questionoffset)*FRACUNIT, questionloop*FRACUNIT))),
+				qm,
+				V_MODULATE|V_NOSCALEPATCH
+			);
+		} else {
+			// Background gradient
+			V_DrawFixedPatch(0, 0, FRACUNIT, 0, bg, NULL);
 
-		// Scrolling question mark overlay
-		V_DrawFixedPatch(
-			-((160 + questionoffset)*FRACUNIT)/questionslow,
-			-(4*FRACUNIT) - (245*(FixedDiv((questionloop - questionoffset)*FRACUNIT, questionloop*FRACUNIT))),
-			FRACUNIT,
-			V_MODULATE,
-			qm,
-			NULL);
+			// Scrolling question mark overlay
+			V_DrawFixedPatch(
+				-((160 + questionoffset)*FRACUNIT)/questionslow,
+				-(4*FRACUNIT) - (245*(FixedDiv((questionloop - questionoffset)*FRACUNIT, questionloop*FRACUNIT))),
+				FRACUNIT,
+				V_MODULATE,
+				qm,
+				NULL);
+		}
+
 #undef questionslow
 #undef questionloop
+	}
+
+
+	if (IS_WEIRD_RES()) {
+		V_DrawFadeFill(-bufferspace, 9, bufferspace, (challengesgridstep * CHALLENGEGRIDHEIGHT) + 2, 0, 31, challengetransparentstrength);
+		V_DrawFadeFill(BASEVIDWIDTH, 9, bufferspace, (challengesgridstep * CHALLENGEGRIDHEIGHT) + 2, 0, 31, challengetransparentstrength);
 	}
 
 	// Do underlay for everything else early so the bottom of the reticule doesn't get shaded over.
@@ -8677,6 +8750,11 @@ void M_DrawChallenges(void)
 			W_CachePatchName("MENUHINT", PU_CACHE));
 
 		V_DrawFadeFill(0, y+27, BASEVIDWIDTH, BASEVIDHEIGHT - (y+27), 0, 31, challengetransparentstrength);
+
+		if (IS_WEIRD_RES()) {
+			V_DrawFadeFill(-bufferspace ,y+6, bufferspace, BASEVIDHEIGHT - (y+6), 0, 31, challengetransparentstrength);
+			V_DrawFadeFill(BASEVIDWIDTH, y+6, bufferspace, BASEVIDHEIGHT - (y+6), 0, 31, challengetransparentstrength);
+		}
 	}
 
 	if (gamedata->challengegrid == NULL || challengesmenu.extradata == NULL)

--- a/src/k_menudraw.c
+++ b/src/k_menudraw.c
@@ -275,7 +275,9 @@ void M_UpdateMenuBGImage(boolean forceReset)
 
 	if (forceReset == false && strcmp(bgImageName, oldName))
 	{
-		bgImageScroll = (3 * BASEVIDWIDTH) * (FRACUNIT / 4);
+		// Radio
+		const INT32 VID_WIDTH = IS_WEIRD_RES() ? vid.width : BASEVIDWIDTH;
+		bgImageScroll = (3 * VID_WIDTH) * (FRACUNIT / 4);
 	}
 
 	if (forceReset == true)
@@ -303,14 +305,26 @@ void M_DrawMenuBackground(void)
 		bgMapImage = W_CachePatchName("MENUBG4", PU_CACHE);
 	}
 
-	V_DrawFixedPatch(0, 0, FRACUNIT, 0, bgMapImage, R_GetTranslationColormap(TC_RAINBOW, SKINCOLOR_SLATE, GTC_MENUCACHE));
-	V_DrawFixedPatch(0, 0, FRACUNIT, V_ADD, W_CachePatchName("MENUCUTD", PU_CACHE), NULL);
-	V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName("MENUCUT", PU_CACHE), NULL);
+	if (IS_WEIRD_RES()) {
+		V_DrawAdaptiveScaledFullScreenPatch(bgMapImage, R_GetTranslationColormap(TC_RAINBOW, SKINCOLOR_SLATE, GTC_MENUCACHE), 0);
+		V_DrawAdaptiveScaledFullScreenPatch(W_CachePatchName("MENUCUTD", PU_CACHE), NULL, V_ADD);
+		V_DrawAdaptiveScaledFullScreenPatch(W_CachePatchName("MENUCUT", PU_CACHE), NULL, 0);
 
-	V_DrawFixedPatch(-bgImageScroll, 0, FRACUNIT, 0, W_CachePatchName("MENUBG1", PU_CACHE), NULL);
-	V_DrawFixedPatch(-bgImageScroll, 0, FRACUNIT, 0, W_CachePatchName(bgImageName, PU_CACHE), NULL);
+		V_DrawAdaptiveScaledPatchWithCoords(-bgImageScroll, 0, W_CachePatchName("MENUBG1", PU_CACHE), V_NOSCALEPATCH);
+		V_DrawAdaptiveScaledPatchWithCoords(-bgImageScroll, 0, W_CachePatchName(bgImageName, PU_CACHE), V_NOSCALEPATCH);
 
-	V_DrawFixedPatch(0, (BASEVIDHEIGHT + 16) * FRACUNIT, FRACUNIT, V_SUBTRACT, W_CachePatchName("MENUBG2", PU_CACHE), NULL);
+		V_DrawFixedPatch(0, (BASEVIDHEIGHT + 16) * FRACUNIT, FRACUNIT, V_SUBTRACT|V_NOSCALEPATCH, W_CachePatchName("MENUBG2", PU_CACHE), NULL);
+	} else {
+		V_DrawFixedPatch(0, 0, FRACUNIT, 0, bgMapImage, R_GetTranslationColormap(TC_RAINBOW, SKINCOLOR_SLATE, GTC_MENUCACHE));
+		V_DrawFixedPatch(0, 0, FRACUNIT, V_ADD, W_CachePatchName("MENUCUTD", PU_CACHE), NULL);
+		V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName("MENUCUT", PU_CACHE), NULL);
+	
+		V_DrawFixedPatch(-bgImageScroll, 0, FRACUNIT, 0, W_CachePatchName("MENUBG1", PU_CACHE), NULL);
+		V_DrawFixedPatch(-bgImageScroll, 0, FRACUNIT, 0, W_CachePatchName("MENUBG1", PU_CACHE), NULL);
+		V_DrawFixedPatch(-bgImageScroll, 0, FRACUNIT, 0, W_CachePatchName(bgImageName, PU_CACHE), NULL);
+
+		V_DrawFixedPatch(0, (BASEVIDHEIGHT + 16) * FRACUNIT, FRACUNIT, V_SUBTRACT, W_CachePatchName("MENUBG2", PU_CACHE), NULL);
+	}
 
 	V_DrawFixedPatch(8 * FRACUNIT, -bgText1Scroll,
 		FRACUNIT, V_SUBTRACT, text1, NULL);
@@ -335,7 +349,11 @@ void M_DrawMenuBackground(void)
 
 	if (bgImageScroll > 0)
 	{
-		bgImageScroll -= (MENUBG_IMAGESCROLL*renderdeltatics);
+		INT32 bgImageScrollAmount = MENUBG_IMAGESCROLL;
+		if (IS_WEIRD_RES())
+			bgImageScrollAmount = (MENUBG_IMAGESCROLL * (int)(vid.width/BASEVIDWIDTH));
+		
+		bgImageScroll -= (bgImageScrollAmount*renderdeltatics);
 		if (bgImageScroll < 0)
 		{
 			bgImageScroll = 0;
@@ -490,7 +508,8 @@ void M_DrawMenuForeground(void)
 	if ((!menuactive || currentMenu != &PAUSE_PlaybackMenuDef) && // this obscures replay menu and I want to put in minimal effort to fix that
 		((vid.width % BASEVIDWIDTH != 0) || (vid.height % BASEVIDHEIGHT != 0)))
 	{
-		V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName("WEIRDRES", PU_CACHE), NULL);
+		// Radio: What if...
+		// V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName("WEIRDRES", PU_CACHE), NULL);
 	}
 }
 
@@ -503,8 +522,16 @@ static void M_DrawMenuTooltips(void)
 {
 	if (currentMenu->menuitems[itemOn].tooltip != NULL)
 	{
-		V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName("MENUHINT", PU_CACHE), NULL);
-		V_DrawCenteredThinString(BASEVIDWIDTH/2, 12, 0, currentMenu->menuitems[itemOn].tooltip);
+		if (IS_WEIRD_RES()) {
+			// V_DrawHorizontallyScaledFullScreenPatch(W_CachePatchName("MENUHINT", PU_CACHE));
+			V_DrawFixedPatch(0, 0, FRACUNIT, V_SNAPTOTOP, W_CachePatchName("MENUHINT", PU_CACHE), NULL);
+			V_DrawCenteredThinString(BASEVIDWIDTH/2, 12, V_SNAPTOTOP, currentMenu->menuitems[itemOn].tooltip);
+
+		} else {
+			V_DrawFixedPatch(0, 0, FRACUNIT, 0, W_CachePatchName("MENUHINT", PU_CACHE), NULL);
+			V_DrawCenteredThinString(BASEVIDWIDTH/2, 12, 0, currentMenu->menuitems[itemOn].tooltip);
+
+		}
 	}
 }
 
@@ -4825,14 +4852,22 @@ void M_DrawOptionsCogs(void)
 		if (optionsmenu.fade)
 		{
 			c2 = R_GetTranslationColormap(TC_DEFAULT, optionsmenu.lastcolour, GTC_CACHE);
-			V_DrawFixedPatch(0, 0, FRACUNIT, 0, back, c2);
+			if (IS_WEIRD_RES()) {
+				V_DrawAdaptiveScaledFullScreenPatch(back, c2, V_NOSCALEPATCH);
+			} else {
+				V_DrawFixedPatch(0, 0, FRACUNIT, 0, back, c2);
+			}
 
 			// prepare fade flag:
 			tflag = min(V_90TRANS, (optionsmenu.fade)<<V_ALPHASHIFT);
 
 		}
 		c = R_GetTranslationColormap(TC_DEFAULT, optionsmenu.currcolour, GTC_CACHE);
-		V_DrawFixedPatch(0, 0, FRACUNIT, tflag, back, c);
+		if (IS_WEIRD_RES()) {
+			V_DrawAdaptiveScaledFullScreenPatch(back, c, V_NOSCALEPATCH|tflag);
+		} else {
+			V_DrawFixedPatch(0, 0, FRACUNIT, tflag, back, c);
+		}
 	}
 	else
 	{

--- a/src/k_vote.c
+++ b/src/k_vote.c
@@ -833,21 +833,35 @@ static void Y_DrawVoteBackground(void)
 
 	const UINT8 planetFrame = (bgTimer / FRACUNIT) % PLANET_FRAMES;
 
-	V_DrawFixedPatch(
-		0, 0,
-		FRACUNIT, 0,
-		vote_draw.bg_planet[planetFrame], NULL
-	);
-	V_DrawFixedPatch(
-		(BASEVIDWIDTH - vote_draw.bg_checker->width) * FRACUNIT, 0,
-		FRACUNIT, V_ADD|V_TRANSLUCENT,
-		vote_draw.bg_checker, NULL
-	);
-	V_DrawFixedPatch(
-		(BASEVIDWIDTH - vote_draw.bg_checker->width) * FRACUNIT, 0,
-		FRACUNIT, V_ADD|V_TRANSLUCENT,
-		vote_draw.bg_checker, NULL
-	);
+	if (IS_WEIRD_RES()) {
+		V_DrawAdaptiveScaledFullScreenPatch(vote_draw.bg_planet[planetFrame], NULL, V_NOSCALEPATCH);
+		V_DrawFixedPatch(
+			(BASEVIDWIDTH - vote_draw.bg_checker->width) * FRACUNIT, 0,
+			FRACUNIT, V_ADD|V_TRANSLUCENT|V_SNAPTOTOP|V_SNAPTORIGHT,
+			vote_draw.bg_checker, NULL
+		);
+		V_DrawFixedPatch(
+			(BASEVIDWIDTH - vote_draw.bg_checker->width) * FRACUNIT, 0,
+			FRACUNIT, V_ADD|V_TRANSLUCENT|V_SNAPTOTOP|V_SNAPTORIGHT,
+			vote_draw.bg_checker, NULL
+		);
+	} else {
+		V_DrawFixedPatch(
+			0, 0,
+			FRACUNIT, 0,
+			vote_draw.bg_planet[planetFrame], NULL
+		);
+		V_DrawFixedPatch(
+			(BASEVIDWIDTH - vote_draw.bg_checker->width) * FRACUNIT, 0,
+			FRACUNIT, V_ADD|V_TRANSLUCENT,
+			vote_draw.bg_checker, NULL
+		);
+		V_DrawFixedPatch(
+			(BASEVIDWIDTH - vote_draw.bg_checker->width) * FRACUNIT, 0,
+			FRACUNIT, V_ADD|V_TRANSLUCENT,
+			vote_draw.bg_checker, NULL
+		);
+	}
 
 	levelPos += FixedMul(TEXT_DERR_SCROLL, renderdeltatics);
 	while (levelPos > levelLoop)
@@ -874,16 +888,20 @@ static void Y_DrawVoteBackground(void)
 		derrPos -= derrLoop;
 	}
 
+	INT32 derrtextflags = 0;
+	if (IS_WEIRD_RES())
+		derrtextflags = V_SNAPTOBOTTOM;
+
 	V_DrawFixedPatch(
 		-derrPos,
 		(BASEVIDHEIGHT - vote_draw.bg_derrText->height) * FRACUNIT,
-		FRACUNIT, V_SUBTRACT,
+		FRACUNIT, V_SUBTRACT|derrtextflags,
 		vote_draw.bg_derrText, NULL
 	);
 	V_DrawFixedPatch(
 		-derrPos + derrLoop,
 		(BASEVIDHEIGHT - vote_draw.bg_derrText->height) * FRACUNIT,
-		FRACUNIT, V_SUBTRACT,
+		FRACUNIT, V_SUBTRACT|derrtextflags,
 		vote_draw.bg_derrText, NULL
 	);
 

--- a/src/menus/extras-egg-tv.cpp
+++ b/src/menus/extras-egg-tv.cpp
@@ -18,6 +18,9 @@
 #include "../discord.h"
 #endif
 
+// Radio
+#include "../radioracers/rr_cvar.h"
+
 using namespace srb2::menus::egg_tv;
 
 namespace
@@ -33,6 +36,11 @@ void M_DrawEggTV()
 boolean M_QuitEggTV()
 {
 	g_egg_tv = {};
+
+	// Radio
+	// And restore the old highreshudscale value
+	CV_SetValue(&cv_highreshudscale, cv_highreshudscale_temp.value);
+	CV_StealthSet(&cv_highreshudscale_temp, "");
 
 	return true;
 }
@@ -136,6 +144,14 @@ void M_EggTV(INT32 choice)
 	g_egg_tv = std::make_unique<EggTV>();
 
 	M_SetupNextMenu(&EXTRAS_EggTVDef, false);
+
+	// Radio
+	// Can't dynamically re-scale the background elements, they're all nested with the main background
+	// So, temporarily reset the highreshudscale cvar
+	if (cv_highreshudscale.value > 1) {
+		CV_StealthSetValue(&cv_highreshudscale_temp, cv_highreshudscale.value);
+		CV_SetValue(&cv_highreshudscale, FRACUNIT);
+	}
 
 #ifdef HAVE_DISCORDRPC
 	DRPC_UpdatePresence();

--- a/src/menus/options-video-1.c
+++ b/src/menus/options-video-1.c
@@ -14,12 +14,18 @@
 #include "../r_fps.h" // fps cvars
 #include "../r_main.h"
 
+// Radio
+#include "../radioracers/rr_cvar.h"
+
 // options menu
 menuitem_t OPTIONS_Video[] =
 {
 
 	{IT_STRING | IT_SUBMENU, "Resolution...", "Change the aspect ratio and image quality.",
 		NULL, {.submenu = &OPTIONS_VideoModesDef}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Resolution Scale", "Change the scale that the HUD is drawn at. Targeted for higher resolutions.",
+		NULL, {.cvar = &cv_highreshudscale}, 0, 0},
 
 	{IT_NOTHING|IT_SPACE, NULL, NULL,
 		NULL, {NULL}, 0, 0},

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -103,6 +103,7 @@ extern consvar_t cv_toggle_race_minimap;    // Toggle the minimap
 extern consvar_t cv_toggle_race_standings;    // Toggle the player standings
 extern consvar_t cv_toggle_trick_cool;    // Toggle the "COOL!" graphic when you do a successful trick
 extern consvar_t cv_show_dangerous_player_check; // Draw arrows on the side of the HUD showing any incoming danger
+extern consvar_t cv_highreshudscale; // Force a higher scaling for the HUD to be drawn at
 
 // HUD -- Hudfeed
 extern consvar_t cv_hudfeed_enabled; // Self-explanatory

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -104,6 +104,7 @@ extern consvar_t cv_toggle_race_standings;    // Toggle the player standings
 extern consvar_t cv_toggle_trick_cool;    // Toggle the "COOL!" graphic when you do a successful trick
 extern consvar_t cv_show_dangerous_player_check; // Draw arrows on the side of the HUD showing any incoming danger
 extern consvar_t cv_highreshudscale; // Force a higher scaling for the HUD to be drawn at
+extern consvar_t cv_highreshudscale_temp; // Temporarily store old value of cv_highreshudscale
 
 // HUD -- Hudfeed
 extern consvar_t cv_hudfeed_enabled; // Self-explanatory

--- a/src/screen.h
+++ b/src/screen.h
@@ -44,8 +44,8 @@ extern "C" {
 // we try to re-allocate a minimum of buffers for stability of the memory,
 // so all the small-enough tables based on screen size, are allocated once
 // and for all at the maximum size.
-#define MAXVIDWIDTH 1920 // don't set this too high because actually
-#define MAXVIDHEIGHT 1200 // lots of tables are allocated with the MAX size.
+#define MAXVIDWIDTH 2560 // don't set this too high because actually
+#define MAXVIDHEIGHT 1440 // lots of tables are allocated with the MAX size.
 #define BASEVIDWIDTH 320 // NEVER CHANGE THIS! This is the original
 #define BASEVIDHEIGHT 200 // resolution of the graphics.
 

--- a/src/sdl/i_video.cpp
+++ b/src/sdl/i_video.cpp
@@ -92,7 +92,7 @@
 #endif
 
 // maximum number of windowed modes (see windowedModes[][])
-#define MAXWINMODES (19)
+#define MAXWINMODES (20)
 
 using namespace srb2;
 
@@ -146,6 +146,7 @@ static uint32_t g_rhi_generation = 0;
 // windowed video modes from which to choose from.
 static INT32 windowedModes[MAXWINMODES][2] =
 {
+	{2560,1440}, // 1.66
 	{1920,1200}, // 1.60,6.00
 	{1920,1080}, // 1.66
 	{1680,1050}, // 1.60,5.25

--- a/src/v_video.cpp
+++ b/src/v_video.cpp
@@ -3763,10 +3763,10 @@ void V_Recalc(void)
 	// Credit to Alufolie for this (from Indev450/SRB2Kart-Saturn)
 	if ((vid.width > 720) && (vid.height > 1280)) // ehhhh well this thing has so many issues, so ill lock it to higher resolutions instead
 	{
-		vid.dupx = FixedDiv(vid.dupx, 6*FRACUNIT/5);
-		vid.dupy = FixedDiv(vid.dupy, 6*FRACUNIT/5);
-		vid.fdupx = FixedDiv(vid.fdupx, 6*FRACUNIT/5);
-		vid.fdupy = FixedDiv(vid.fdupy, 6*FRACUNIT/5);
+		vid.dupx = FixedDiv(vid.dupx, cv_highreshudscale.value);
+		vid.dupy = FixedDiv(vid.dupy, cv_highreshudscale.value);
+		vid.fdupx = FixedDiv(vid.fdupx, cv_highreshudscale.value);
+		vid.fdupy = FixedDiv(vid.fdupy, cv_highreshudscale.value);
 	}
 
 #ifdef HWRENDER

--- a/src/v_video.cpp
+++ b/src/v_video.cpp
@@ -3758,6 +3758,15 @@ void V_Recalc(void)
 	vid.fdupx = FixedDiv(vid.width*FRACUNIT, BASEVIDWIDTH*FRACUNIT);
 	vid.fdupy = FixedDiv(vid.height*FRACUNIT, BASEVIDHEIGHT*FRACUNIT);
 
+	// Credit to Alufolie for this (from Indev450/SRB2Kart-Saturn)
+	if ((vid.width > 720) && (vid.height > 1280)) // ehhhh well this thing has so many issues, so ill lock it to higher resolutions instead
+	{
+		vid.dupx = FixedDiv(vid.dupx, 6*FRACUNIT/5);
+		vid.dupy = FixedDiv(vid.dupy, 6*FRACUNIT/5);
+		vid.fdupx = FixedDiv(vid.fdupx, 6*FRACUNIT/5);
+		vid.fdupy = FixedDiv(vid.fdupy, 6*FRACUNIT/5);
+	}
+
 #ifdef HWRENDER
 	//if (rendermode != render_opengl && rendermode != render_none) // This was just placing it incorrectly at non aspect correct resolutions in opengl
 	// 13/11/18:
@@ -3856,4 +3865,49 @@ char *V_ParseText(const char *rawText)
 	using srb2::Draw;
 
 	return Z_StrDup(srb2::Draw::TextElement().parse(rawText).string().c_str());
+}
+
+// Credit to Alufolie for this function (from Indev450/SRB2Kart-Saturn), tweaked slightly for RingRacers purposes
+// Draws a patch and tries to always fill the screen with the patch
+void V_DrawAdaptiveScaledFullScreenPatch(patch_t *patch, uint8_t* c, INT32 flags)
+{
+	fixed_t x = 0, y = 0;
+	fixed_t scale = ((vid.width * FRACUNIT) / patch->width); // fit the screen horizontally
+	fixed_t scaled_height = FixedMul(patch->height << FRACBITS, scale);
+
+	// however, if this means the patch doesent fill out the screen vertically then
+	if (scaled_height < (vid.height << FRACBITS))
+	{
+		scale = ((vid.height * FRACUNIT) / patch->height); // scale it to fit the screen vertically
+		x = ((vid.width << FRACBITS) - FixedMul(patch->width << FRACBITS, scale)) / 2;
+	}
+	else
+		y = (vid.height << FRACBITS) - scaled_height;
+
+	V_DrawFixedPatch(x, y, scale, V_NOSCALEPATCH|flags, patch, c);
+}
+
+// Credit to Alufolie for this function (from Indev450/SRB2Kart-Saturn), tweaked slightly for RingRacers purposes
+// Draws a patch and scales it to fill out the screen horizontally
+// centers the patch when its too small to fit the screen vertically
+void V_DrawHorizontallyScaledFullScreenPatch(patch_t *patch)
+{
+	fixed_t scale = ((vid.width * FRACUNIT) / patch->width);
+	fixed_t scaled_height = FixedMul(patch->height << FRACBITS, scale);
+	fixed_t y = (vid.height << FRACBITS) - scaled_height;
+
+	V_DrawFixedPatch(0, 0, scale, V_NOSCALEPATCH, patch, NULL);
+}
+
+// Same as V_DrawAdaptiveScaledFullScreenPatch, but we only need the scale
+void V_DrawAdaptiveScaledPatchWithCoords(fixed_t x, fixed_t y, patch_t *patch, INT32 flags)
+{
+	fixed_t scale = ((vid.width * FRACUNIT) / patch->width); // fit the screen horizontally
+	fixed_t scaled_height = FixedMul(patch->height << FRACBITS, scale);
+
+	// however, if this means the patch doesent fill out the screen vertically then
+	if (scaled_height < (vid.height << FRACBITS))
+		scale = ((vid.height * FRACUNIT) / patch->height); // scale it to fit the screen vertically
+	
+	V_DrawFixedPatch(x, y, scale, flags, patch, NULL);
 }

--- a/src/v_video.cpp
+++ b/src/v_video.cpp
@@ -1329,23 +1329,25 @@ void V_DrawFadeFill(INT32 x, INT32 y, INT32 w, INT32 h, INT32 c, UINT16 color, U
 		V_AdjustXYWithSnap(&x, &y, c, dupx, dupy);
 	}
 
-	if (x >= vid.width || y >= vid.height)
-		return; // off the screen
-	if (x < 0) {
-		w += x;
-		x = 0;
+	if (!IS_WEIRD_RES()) {
+		if (x >= vid.width || y >= vid.height)
+			return; // off the screen
+		if (x < 0) {
+			w += x;
+			x = 0;
+		}
+		if (y < 0) {
+			h += y;
+			y = 0;
+		}
+	
+		if (w <= 0 || h <= 0)
+			return; // zero width/height wouldn't draw anything
+		if (x + w > vid.width)
+			w = vid.width-x;
+		if (y + h > vid.height)
+			h = vid.height-y;
 	}
-	if (y < 0) {
-		h += y;
-		y = 0;
-	}
-
-	if (w <= 0 || h <= 0)
-		return; // zero width/height wouldn't draw anything
-	if (x + w > vid.width)
-		w = vid.width-x;
-	if (y + h > vid.height)
-		h = vid.height-y;
 
 	float r;
 	float g;

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -438,6 +438,13 @@ void V_DrawPatchFill(patch_t *pat);
 void VID_BlitLinearScreen(const UINT8 *srcptr, UINT8 *destptr, INT32 width, INT32 height, size_t srcrowbytes,
 	size_t destrowbytes);
 
+// Credit to Alufolie for these functions (from Indev450/SRB2Kart-Saturn), tweaked slightly for RingRacers purposes
+void V_DrawAdaptiveScaledFullScreenPatch(patch_t *patch, uint8_t* c, INT32 flags);
+void V_DrawHorizontallyScaledFullScreenPatch(patch_t *patch);
+
+// For widescreen
+#define IS_WEIRD_RES() ((vid.width % BASEVIDWIDTH != 0) || (vid.height % BASEVIDHEIGHT != 0))
+void V_DrawAdaptiveScaledPatchWithCoords(fixed_t x, fixed_t y, patch_t *patch, INT32 flags);
 /**
  * Display the software framebuffer to the screen. Added in RHI conversion; software is not implicitly displayed by the
  * system.

--- a/src/y_inter.cpp
+++ b/src/y_inter.cpp
@@ -1907,13 +1907,17 @@ void Y_DrawIntermissionHeader(fixed_t x, fixed_t y, boolean gotthrough, const ch
 
 static void Y_DrawMapTitleString(fixed_t x, const char *name)
 {
+	INT32 extraflags = 0;
+	if (IS_WEIRD_RES())
+		extraflags = V_SNAPTOBOTTOM;
+
 	V_DrawStringScaled(
 		x - ttlscroll,
 		(BASEVIDHEIGHT - 73) * FRACUNIT,
 		FRACUNIT,
 		FRACUNIT,
 		FRACUNIT,
-		V_SUBTRACT | V_60TRANS,
+		V_SUBTRACT | V_60TRANS | extraflags,
 		NULL,
 		LSHI_FONT,
 		name
@@ -1984,17 +1988,25 @@ void Y_IntermissionDrawer(void)
 	fixed_t chkloop = SHORT(rbgchk->width)*FRACUNIT;
 
 	UINT8 *bgcolor = R_GetTranslationColormap(TC_INTERMISSION, static_cast<skincolornum_t>(0), GTC_CACHE);
+	INT32 intermissiontextflags = V_SUBTRACT;
+	INT32 intermissioncheckflags = V_SUBTRACT;
 
 	// Draw the background
-	K_DrawMapThumbnail(0, 0, BASEVIDWIDTH<<FRACBITS, (data.encore ? V_FLIP : 0), prevmap, bgcolor);
+	if (IS_WEIRD_RES()) {
+		intermissiontextflags |= V_SNAPTOBOTTOM;
+		intermissioncheckflags |= V_SNAPTOTOP;
+		K_DrawMapThumbnailWidescreen(0, 0, BASEVIDWIDTH<<FRACBITS, (data.encore ? V_FLIP : 0), prevmap, bgcolor);
+	} else {
+		K_DrawMapThumbnail(0, 0, BASEVIDWIDTH<<FRACBITS, (data.encore ? V_FLIP : 0), prevmap, bgcolor);
+	}
 
 	for (x = -mqscroll; x < (BASEVIDWIDTH * FRACUNIT); x += mqloop)
 	{
-		V_DrawFixedPatch(x, 154<<FRACBITS, FRACUNIT, V_SUBTRACT, rrmq, NULL);
+		V_DrawFixedPatch(x, 154<<FRACBITS, FRACUNIT, intermissiontextflags, rrmq, NULL);
 	}
 
-	V_DrawFixedPatch(chkscroll, 0, FRACUNIT, V_SUBTRACT, rbgchk, NULL);
-	V_DrawFixedPatch(chkscroll - chkloop, 0, FRACUNIT, V_SUBTRACT, rbgchk, NULL);
+	V_DrawFixedPatch(chkscroll, 0, FRACUNIT, intermissioncheckflags, rbgchk, NULL);
+	V_DrawFixedPatch(chkscroll - chkloop, 0, FRACUNIT, intermissioncheckflags, rbgchk, NULL);
 
 	fixed_t ttlloop = Y_DrawMapTitle();
 
@@ -2052,7 +2064,7 @@ skiptallydrawer:
 		goto finalcounter;
 
 	// Returns early if there's no roundqueue entries to draw
-	Y_RoundQueueDrawer(&data, 0, true, false, false);
+	Y_RoundQueueDrawer(&data, 0, true, IS_WEIRD_RES(), false);
 
 	if (netgame)
 	{


### PR DESCRIPTION
> Credit to @Indev450 for the `highreshudscale` cvar from [Indev450/SRB2Kart-Saturn.](https://github.com/Indev450/SRB2Kart-Saturn)

`Video Options`  ⟶ `Resolution Scale`
<img width="1492" height="349" alt="image" src="https://github.com/user-attachments/assets/705fcf3d-bb56-475c-a2e3-c4c031b53a1b" />

Control the scale that the HUD will be drawn at - set at 120% max. 
Here are some comparisons:

| 1920x1080, 100% HUD scale: | 2560x1440, 120% HUD scale: |
| ------------- | ------------- |
| <img width="320" height="200" alt="ringracers0008" src="https://github.com/user-attachments/assets/e1a076f2-f25b-4e63-8749-8c9fdb2e910b" /> | <img width="320" height="200" alt="ringracers0014" src="https://github.com/user-attachments/assets/f3ba9857-941d-4717-af8e-e8ab70dd6f3d" /> |
| <img width="320" height="200" alt="ringracers0009" src="https://github.com/user-attachments/assets/410d6d8c-155d-439b-97b9-9ab95690bc63" />| <img width="320" height="200" alt="ringracers0015" src="https://github.com/user-attachments/assets/94e23485-1b02-47e2-a23a-24e5cfb1136b" /> |
| <img width="320" height="200" alt="ringracers0010" src="https://github.com/user-attachments/assets/b387d121-81a8-47cc-8b7a-fb87265228b7" />| <img width="320" height="200" alt="ringracers0016" src="https://github.com/user-attachments/assets/aade7d34-f18b-45fe-8811-bc34d4988cbe" /> |
|<img width="320" height="200" alt="ringracers0012" src="https://github.com/user-attachments/assets/99fe0d45-1779-4d27-a529-a4c27bf386f7" />| <img width="320" height="200" alt="ringracers0019" src="https://github.com/user-attachments/assets/8d8afa6d-6cb6-47d4-956f-20739b253948" /> |
|<img width="320" height="200" alt="ringracers0013" src="https://github.com/user-attachments/assets/177b3acb-4e4d-4289-b1fc-34032f163a75" />| <img width="320" height="200" alt="ringracers0020" src="https://github.com/user-attachments/assets/2b56d51a-3f99-4961-bbb3-03347a2e2d7e" /> |
|<img width="320" height="200" alt="ringracers0022" src="https://github.com/user-attachments/assets/36fe6ba4-9a96-4e30-ae4c-1a4b6a9bfa47" /> |<img width="320" height="200" alt="ringracers0023" src="https://github.com/user-attachments/assets/274b5bed-6dde-42ff-8336-6604f3cc3b86" />|
|<img width="320" height="200" alt="ringracers0025" src="https://github.com/user-attachments/assets/64abf5a2-7144-4bc9-9a74-81ed0b65cbaf" />|<img width="320" height="200" alt="ringracers0024" src="https://github.com/user-attachments/assets/65d94a9d-846c-4995-b90a-a675b0ad0dbb" /> |

Non-green resolutions draw the `WEIRDRES` patch in the foreground.
So, in exchange for _slightly_ broken consistent menu animations, the HUD gets a lot more breathing room, especially in-game.

Treat this feature as experimental, since I wasn't able to dynamically fix _all_ menus (see: EggTV, scrolling background elements), but I'm not picky, so I personally don't mind.

<br/>
<br/>
<br/>
<br/>
<br/>
<br/>
<br/>

![RougeKiss-2x](https://github.com/user-attachments/assets/d00c3e65-c668-4ed0-8d47-0d257850b015)

