### PR TITLE
Save bespoke console variables to custom configuration file

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -2458,7 +2458,7 @@ void CV_SaveVariables(FILE *f)
 	consvar_t *cvar;
 
 	for (cvar = consvar_vars; cvar; cvar = cvar->next)
-		if (cvar->flags & CV_SAVE)
+		if (!cvar->is_radio_cvar && cvar->flags & CV_SAVE)
 		{
 			char stringtowrite[MAXTEXTCMD+1];
 
@@ -2501,6 +2501,62 @@ void CV_SaveVariables(FILE *f)
 			fprintf(f, "%s \"%s\"\n", cvar->name, string);
 		}
 }
+
+/**
+ * See CV_SaveVariables.
+ * Same functionality, filters cvars with the radio flag.
+ * 
+ * \param f File to save to.
+ */
+void CV_SaveRadioVariables(FILE *f)
+{
+	consvar_t *cvar;
+
+	for (cvar = consvar_vars; cvar; cvar = cvar->next)
+		if (cvar->is_radio_cvar && (cvar->flags & CV_SAVE))
+		{
+			char stringtowrite[MAXTEXTCMD+1];
+
+			const char * string;
+
+			if (cvar->revert.v.string != NULL)
+			{
+				string = cvar->revert.v.string;
+			}
+			else
+			{
+				string = cvar->string;
+			}
+
+			// Silly hack for Min/Max vars
+#define MINVAL 0
+#define MAXVAL 1
+			if (
+					cvar->PossibleValue != NULL &&
+					cvar->PossibleValue[0].strvalue &&
+					stricmp(cvar->PossibleValue[0].strvalue, "MIN") == 0
+			){ // bounded cvar
+				int which = stricmp(string, "MAX") == 0;
+
+				if (which || stricmp(string, "MIN") == 0)
+				{
+					INT32 value = cvar->PossibleValue[which].value;
+
+					if (cvar->flags & CV_FLOAT)
+						sprintf(stringtowrite, "%f", FIXED_TO_FLOAT(value));
+					else
+						sprintf(stringtowrite, "%d", value);
+
+					string = stringtowrite;
+				}
+			}
+#undef MINVAL
+#undef MAXVAL
+
+			fprintf(f, "%s \"%s\"\n", cvar->name, string);
+		}
+}
+
 
 //============================================================================
 //                            SCRIPT PARSE

--- a/src/command.h
+++ b/src/command.h
@@ -179,6 +179,9 @@ struct consvar_t //NULL, NULL, 0, NULL, NULL |, 0, NULL, NULL, 0, 0, NULL
 	char changed;         // has variable been changed by the user? 0 = no, 1 = yes
 	consvar_t *next;
 
+	// Radio only
+	boolean is_radio_cvar; // By default, this is empty/false
+
 #ifdef __cplusplus
 	struct Builder;
 
@@ -277,6 +280,9 @@ void CV_AddValue(consvar_t *var, INT32 increment);
 
 // write all CV_SAVE variables to config file
 void CV_SaveVariables(FILE *f);
+
+// write all CV_SAVE variables to RADIO config file
+void CV_SaveRadioVariables(FILE *f);
 
 // load/save gamesate (load and save option and for network join in game)
 void CV_SaveVars(UINT8 **p, boolean in_demo);

--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -170,6 +170,12 @@ struct consvar_t::Builder
 		return *this;
 	}
 
+	Builder& radio()
+	{
+		var_.is_radio_cvar = true;
+		return *this;
+	}
+
 private:
 	Builder& combine_values(values_list_t a, values_list_t b)
 	{
@@ -503,49 +509,49 @@ consvar_t stereoreverse = Player("stereoreverse", "Off").on_off();
  * RadioRacers: cvars for custom miscellanous functionalities
  */
 // Backport of accessibility option from SRB2Kart.
-consvar_t cv_translucenthud = Player("translucenthud", "10").min_max(0, 10);
+consvar_t cv_translucenthud = Player("translucenthud", "10").min_max(0, 10).radio();
 
-consvar_t cv_toggle_nametags = Player("nametags", "On").on_off();
-consvar_t cv_driftsparkrate_size = Player("driftsparkpulsesize", "2.95").floating_point().min_max(1, 30*FRACUNIT).step_amount(FRACUNIT).save();
+consvar_t cv_toggle_nametags = Player("nametags", "On").on_off().radio();
+consvar_t cv_driftsparkrate_size = Player("driftsparkpulsesize", "2.95").floating_point().min_max(1, 30*FRACUNIT).step_amount(FRACUNIT).save().radio();
 
 // Precise countdown
-consvar_t cv_precise_countdown = Player("precisecountdown", "On").on_off();
+consvar_t cv_precise_countdown = Player("precisecountdown", "On").on_off().radio();
 
 // Vote Snitch
-consvar_t cv_votesnitch = Player("votesnitch", "On").on_off();
+consvar_t cv_votesnitch = Player("votesnitch", "On").on_off().radio();
 
 // Local Encore Mode Palettes
-consvar_t cv_applylocalencore = Player("localencore", "Off").values({{0, "Off"}, {1, "On"}}).dont_save().onchange_noinit(KartLocalEncore_OnChange);
+consvar_t cv_applylocalencore = Player("localencore", "Off").values({{0, "Off"}, {1, "On"}}).dont_save().onchange_noinit(KartLocalEncore_OnChange).radio();
 
 // Observation Haki
-consvar_t cv_applyhaki = Player("hakimode", "Off").values({{0, "Off"}, {1, "On"}}).dont_save().onchange_noinit(KartHaki_OnChange);
+consvar_t cv_applyhaki = Player("hakimode", "Off").values({{0, "Off"}, {1, "On"}}).dont_save().onchange_noinit(KartHaki_OnChange).radio();
 
 // Show 'S' ranks in the tally and player standings
-consvar_t cv_show_s_ranks = Player("showperfectranks", "On").on_off();
+consvar_t cv_show_s_ranks = Player("showperfectranks", "On").on_off().radio();
 
 // Rings Ghost Accessibility
-consvar_t cv_accessibility_rings_hide = Player("ringsaccessibility", "On").on_off();
+consvar_t cv_accessibility_rings_hide = Player("ringsaccessibility", "On").on_off().radio();
 
 // Hudfeed
-consvar_t cv_hudfeed_enabled = Player("hudfeed", "Yes").yes_no().onchange_noinit(RR_Hudfeed_OnChange);
-consvar_t cv_hudfeed_show_faults = Player("hudfeed_show_faults", "Yes").yes_no();
-consvar_t cv_hudfeed_show_grades = Player("hudfeed_show_grades", "Yes").yes_no();
-consvar_t cv_hudfeed_show_snipes = Player("hudfeed_show_snipes", "Yes").yes_no();
+consvar_t cv_hudfeed_enabled = Player("hudfeed", "Yes").yes_no().onchange_noinit(RR_Hudfeed_OnChange).radio();
+consvar_t cv_hudfeed_show_faults = Player("hudfeed_show_faults", "Yes").yes_no().radio();
+consvar_t cv_hudfeed_show_grades = Player("hudfeed_show_grades", "Yes").yes_no().radio();
+consvar_t cv_hudfeed_show_snipes = Player("hudfeed_show_snipes", "Yes").yes_no().radio();
 consvar_t cv_hudfeed_position = Player("hudfeedposition", "Top-Middle").values({
 	{0, "Default"},
 	{1, "Top-Middle"},
 	{2, "Top-Right"},
 	{3, "Bottom-Middle"},
-}).onchange_noinit(RR_UpdateHudFeedConfig);
+}).onchange_noinit(RR_UpdateHudFeedConfig).radio();
 
 // Tripwire
-consvar_t cv_obvious_tripwire = Player("obvioustripwire", "On").on_off().onchange_noinit(	RR_ObviousTripwire_OnChange);
+consvar_t cv_obvious_tripwire = Player("obvioustripwire", "On").on_off().onchange_noinit(RR_ObviousTripwire_OnChange).radio();
 
 // Voltage
-consvar_t cv_obvious_voltage = Player("obviousvoltage", "On").on_off();
+consvar_t cv_obvious_voltage = Player("obviousvoltage", "On").on_off().radio();
 
 // Draw any danger checks on the side of the HUD
-consvar_t cv_show_dangerous_player_check = Player("showdangerplayercheck", "Off").on_off();
+consvar_t cv_show_dangerous_player_check = Player("showdangerplayercheck", "Off").on_off().radio();
 
 // HUD Scaling
 consvar_t cv_highreshudscale = Player("highreshudscale", "Default")
@@ -554,41 +560,42 @@ consvar_t cv_highreshudscale = Player("highreshudscale", "Default")
 		{6*FRACUNIT/5, "120%"}, 
 		{0, NULL}
 	})
-	.onchange_noinit(SCR_Recalc);
+	.onchange_noinit(SCR_Recalc).radio();
 consvar_t cv_highreshudscale_temp = MenuDummy("highreshudscale_temp", "");
 
 // Item timers (not all)
-consvar_t cv_gingeritemtimers = Player("huditemtimers", "On").on_off();
+consvar_t cv_gingeritemtimers = Player("huditemtimers", "On").on_off().radio();
 consvar_t cv_gingeritemtimersbiggertext = Player("huditemtimerssize", "Default").values({
 	{0, "Default"},
 	{1, "Big"}
-});
+}).radio();
 consvar_t cv_gingeritemtimersoffset = Player("huditemtimersoffset", "0").floating_point()
 	.min_max(-180*FRACUNIT, 200*FRACUNIT) // At most 200 (bottom of the screen)
-	.step_amount(FRACUNIT);
+	.step_amount(FRACUNIT)
+	.radio();
 
 // Powerup jingle - straight from HOSTMOD, thanks Tyron.
-consvar_t cv_powersound = Player("powersoundhc", "Off").on_off();
-consvar_t cv_powersoundjoke = Player("powersoundjokehc", "On").on_off().onchange_noinit(KartExtraPowerSound_OnChange);
+consvar_t cv_powersound = Player("powersoundhc", "Off").on_off().radio();
+consvar_t cv_powersoundjoke = Player("powersoundjokehc", "On").on_off().onchange_noinit(KartExtraPowerSound_OnChange).radio();
 
-consvar_t cv_show_riders_finish_ticker = Player("ridersfinishticker", "On").on_off().onchange_noinit(KartFinishLineTicker_OnChange);
+consvar_t cv_show_riders_finish_ticker = Player("ridersfinishticker", "On").on_off().onchange_noinit(KartFinishLineTicker_OnChange).radio();
 
 // Rumble Events
-consvar_t cv_morerumbleevents = Player("morerumbleevents", "On").on_off().onchange(RumbleEvents_OnChange);
-consvar_t cv_rr_rumble_wall_bump = Player("rr_rumble_wall_bump", "On").on_off();
-consvar_t cv_rr_rumble_fastfall_bounce = Player("rr_rumble_fastfall_bounce", "On").on_off();
-consvar_t cv_rr_rumble_drift = Player("rr_rumble_drift", "On").on_off();
-consvar_t cv_rr_rumble_spindash = Player("rr_rumble_spindash", "On").on_off();
-consvar_t cv_rr_rumble_tailwhip = Player("rr_rumble_tailwhip", "On").on_off();
-consvar_t cv_rr_rumble_rings = Player("rr_rumble_rings", "On").on_off();
-consvar_t cv_rr_rumble_spheres = Player("rr_rumble_spheres", "On").on_off();
-consvar_t cv_rr_rumble_wavedash = Player("rr_rumble_wavedash", "On").on_off();
+consvar_t cv_morerumbleevents = Player("morerumbleevents", "On").on_off().onchange(RumbleEvents_OnChange).radio();
+consvar_t cv_rr_rumble_wall_bump = Player("rr_rumble_wall_bump", "On").on_off().radio();
+consvar_t cv_rr_rumble_fastfall_bounce = Player("rr_rumble_fastfall_bounce", "On").on_off().radio();
+consvar_t cv_rr_rumble_drift = Player("rr_rumble_drift", "On").on_off().radio();
+consvar_t cv_rr_rumble_spindash = Player("rr_rumble_spindash", "On").on_off().radio();
+consvar_t cv_rr_rumble_tailwhip = Player("rr_rumble_tailwhip", "On").on_off().radio();
+consvar_t cv_rr_rumble_rings = Player("rr_rumble_rings", "On").on_off().radio();
+consvar_t cv_rr_rumble_spheres = Player("rr_rumble_spheres", "On").on_off().radio();
+consvar_t cv_rr_rumble_wavedash = Player("rr_rumble_wavedash", "On").on_off().radio();
 
 // Rings drawn on player (akin to driftgauge)
 consvar_t cv_ringsonplayer = Player("ringsonplayer", "Custom").values({
 	{0, "Vanilla"}, 
 	{1, "Custom"}
-});
+}).radio();
 
 // Speedometer draw on player (akin to driftguage)
 static void SpeedometerOnPlayer_OnChange(void) {
@@ -598,7 +605,7 @@ static void SpeedometerOnPlayer_OnChange(void) {
 consvar_t cv_speedometeronplayer = Player("speedometeronplayer", "Vanilla").values({
 	{0, "Vanilla"}, 
 	{1, "Custom"}
-}).onchange_noinit(SpeedometerOnPlayer_OnChange);
+}).onchange_noinit(SpeedometerOnPlayer_OnChange).radio();
 
 // EXP draw on player (akin to driftguage)
 static void ExpOnPlayer_OnChange(void) {
@@ -608,7 +615,7 @@ static void ExpOnPlayer_OnChange(void) {
 consvar_t cv_exponplayer = Player("exponplayer", "Vanilla").values({
 	{0, "Vanilla"}, 
 	{1, "Custom"}
-}).onchange_noinit(ExpOnPlayer_OnChange);
+}).onchange_noinit(ExpOnPlayer_OnChange).radio();
 
 // -- Battle
 
@@ -616,24 +623,24 @@ consvar_t cv_exponplayer = Player("exponplayer", "Vanilla").values({
 consvar_t cv_spheremeteronplayer = Player("spheremeteronplayer", "Custom").values({
 	{0, "Vanilla"}, 
 	{1, "Custom"}
-});
+}).radio();
 
 // Alterate Emerald display HUD
 consvar_t cv_customemeraldhud = Player("customemeraldhud", "Full").values({
 	{0, "Vanilla"}, 
 	{1, "Minimal"},
 	{2, "Full"}
-});
+}).radio();
 
 // Toggle Winner announcement at end of the round
-consvar_t cv_battle_toggle_winner_announcement = Player("bttl_toggle_winner_announcement", "On").on_off();
+consvar_t cv_battle_toggle_winner_announcement = Player("bttl_toggle_winner_announcement", "On").on_off().radio();
 
 // Emerald locations on minimap
-consvar_t cv_battle_toggle_emerald_on_minimap = Player("bttl_emerald_on_minimap", "On").on_off();
-consvar_t cv_battle_toggle_ufo_timer_on_minimap = Player("bttl_ufo_timer_on_minimap", "On").on_off();
+consvar_t cv_battle_toggle_emerald_on_minimap = Player("bttl_emerald_on_minimap", "On").on_off().radio();
+consvar_t cv_battle_toggle_ufo_timer_on_minimap = Player("bttl_ufo_timer_on_minimap", "On").on_off().radio();
 
 // Toggle tracking players in the HUD
-consvar_t cv_targetrackplayers = Player("targetrackplayers", "Yes").yes_no();
+consvar_t cv_targetrackplayers = Player("targetrackplayers", "Yes").yes_no().radio();
 
 // -- Race
 
@@ -641,7 +648,7 @@ consvar_t cv_targetrackplayers = Player("targetrackplayers", "Yes").yes_no();
 consvar_t cv_rouletteonplayer = Player("rouletteonplayer", "Custom").values({
 	{0, "Vanilla"}, 
 	{1, "Custom"}
-}).onchange(Roulette_OnChange);
+}).onchange(Roulette_OnChange).radio();
 
 static CV_PossibleValue_t itemboxscale_cons_t[] = {
 	{(4*FRACUNIT)/10, "40%"},
@@ -662,47 +669,47 @@ static CV_PossibleValue_t itemboxposition_cons_t[] = {
 
 // How big should we draw the item roulette?
 // And where exactly should we draw it?
-consvar_t cv_ringbox_roulette_player_scale = Player("ringbox_roulette_player_scale", "60%").values(itemboxscale_cons_t);
-consvar_t cv_item_roulette_player_scale = Player("item_roulette_player_scale", "60%").values(itemboxscale_cons_t);
+consvar_t cv_ringbox_roulette_player_scale = Player("ringbox_roulette_player_scale", "60%").values(itemboxscale_cons_t).radio();
+consvar_t cv_item_roulette_player_scale = Player("item_roulette_player_scale", "60%").values(itemboxscale_cons_t).radio();
 
-consvar_t cv_ringbox_roulette_player_position = Player("ringbox_roulette_player_position", "Right").values(itemboxposition_cons_t);
-consvar_t cv_item_roulette_player_position = Player("item_roulette_player_position", "Left").values(itemboxposition_cons_t);
+consvar_t cv_ringbox_roulette_player_position = Player("ringbox_roulette_player_position", "Right").values(itemboxposition_cons_t).radio();
+consvar_t cv_item_roulette_player_position = Player("item_roulette_player_position", "Left").values(itemboxposition_cons_t).radio();
 
 // Hide the giant big ass letters at the start of the race
-consvar_t cv_hud_hidecountdown = Player("hidecountdown", "Off").on_off();
+consvar_t cv_hud_hidecountdown = Player("hidecountdown", "Off").on_off().radio();
 // Hide the bigass position bulbs at the start of the race
-consvar_t cv_hud_hideposition = Player("hideposition", "Off").on_off();
+consvar_t cv_hud_hideposition = Player("hideposition", "Off").on_off().radio();
 // Hide the bigass lap emblem when you start a new lap
-consvar_t cv_hud_hidelapemblem = Player("hidelapemblem", "Off").on_off();
+consvar_t cv_hud_hidelapemblem = Player("hidelapemblem", "Off").on_off().radio();
 // Draw high-res portraits in the minirankings
-consvar_t cv_hud_usehighresportraits = Player("usehighresportraits", "Yes").yes_no();
+consvar_t cv_hud_usehighresportraits = Player("usehighresportraits", "Yes").yes_no().radio();
 // Restore SRB2Kart behaviour when viewing in-game rankings (i.e. having to hold the button)
-consvar_t cv_holdbuttonforscoreboard = Player("holdbuttonforscoreboard", "No").yes_no();
+consvar_t cv_holdbuttonforscoreboard = Player("holdbuttonforscoreboard", "No").yes_no().radio();
 // Toggle between ANALOG and DIGITAL input display
 consvar_t cv_inputdisplaytoggle = Player("inputdisplaytoggle", "Digital").values({
 	{'2', "Digital"}, 
 	{'4', "Analog"}
-});
+}).radio();
 consvar_t cv_inputdisplaytogglesize = Player("inputdisplaytogglesize", "Mini").values({
 	{0, "Normal"}, 
 	{1, "Mini"}
-});
+}).radio();
 
-consvar_t cv_toggle_position_number = Player("positionnumbertoggle", "On").on_off();
-consvar_t cv_toggle_race_minimap = Player("raceminimaptoggle", "On").on_off();
-consvar_t cv_toggle_trick_cool = Player("tricktexttoggle", "On").on_off();
-consvar_t cv_toggle_race_standings = Player("racestandingstoggle", "On").on_off();
+consvar_t cv_toggle_position_number = Player("positionnumbertoggle", "On").on_off().radio();
+consvar_t cv_toggle_race_minimap = Player("raceminimaptoggle", "On").on_off().radio();
+consvar_t cv_toggle_trick_cool = Player("tricktexttoggle", "On").on_off().radio();
+consvar_t cv_toggle_race_standings = Player("racestandingstoggle", "On").on_off().radio();
 
 // Chat emotes
-consvar_t cv_chat_emotes = Player("chat_emotes", "On").on_off().onchange(RR_ChatEmotes_OnChange);
-consvar_t cv_chat_emotes_animated = Player("chat_emotes_animate", "On").on_off();
-consvar_t cv_chat_emotes_button = Player("chat_emotes_button", "On").on_off();
-consvar_t cv_chat_emotes_preview = Player("chat_emotes_input_preview", "On").on_off();
+consvar_t cv_chat_emotes = Player("chat_emotes", "On").on_off().onchange(RR_ChatEmotes_OnChange).radio();
+consvar_t cv_chat_emotes_animated = Player("chat_emotes_animate", "On").on_off().radio();
+consvar_t cv_chat_emotes_button = Player("chat_emotes_button", "On").on_off().radio();
+consvar_t cv_chat_emotes_preview = Player("chat_emotes_input_preview", "On").on_off().radio();
 consvar_t cv_chat_emotes_sort = Player("chat_emotes_sort", "Alphabetical").values({
 	{0, "Alphabetical"},
 	{1, "Most Used"},
 	{2, "Favourites"}
-}).onchange(RR_ChatEmoteSort_OnChange);
+}).onchange(RR_ChatEmoteSort_OnChange).radio();
 
 /**
  * RadioRacers: END

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1442,6 +1442,9 @@ static void IdentifyVersion(void)
 	snprintf(configfile, sizeof configfile, "%s" PATHSEP CONFIGFILENAME, srb2waddir);
 	configfile[sizeof configfile - 1] = '\0';
 
+	snprintf(configfile_radio, sizeof configfile_radio, "%s" PATHSEP RADIOCONFIGFILENAME, srb2waddir);
+	configfile_radio[sizeof configfile_radio - 1] = '\0';
+
 	D_AddFile(startupiwads, num_startupiwads++, va(spandf,srb2waddir,"data","scripts.pk3"), ASSET_HASH_SCRIPTS_PK3);
 	D_AddFile(startupiwads, num_startupiwads++, va(spandf,srb2waddir,"data","gfx.pk3"), ASSET_HASH_GFX_PK3);
 	D_AddFile(startupiwads, num_startupiwads++, va(spandf,srb2waddir,"data","textures_general.pk3"), ASSET_HASH_TEXTURES_GENERAL_PK3);
@@ -1638,10 +1641,12 @@ void D_SRB2Main(void)
 #if ((defined (__unix__) && !defined (MSDOS)) || defined(__APPLE__) || defined (UNIXCOMMON)) && !defined (__CYGWIN__)
 			I_Error("Please set $HOME to your home directory\n");
 #else
-			if (dedicated)
+			if (dedicated) {
 				snprintf(configfile, sizeof configfile, "d" CONFIGFILENAME);
-			else
+			} else {
 				snprintf(configfile, sizeof configfile, CONFIGFILENAME);
+				snprintf(configfile_radio, sizeof configfile_radio, RADIOCONFIGFILENAME);
+			}
 #endif
 		}
 		else
@@ -1649,10 +1654,12 @@ void D_SRB2Main(void)
 			// use user specific config file
 #ifdef DEFAULTDIR
 			snprintf(srb2home, sizeof srb2home, "%s" PATHSEP DEFAULTDIR, userhome);
-			if (dedicated)
+			if (dedicated) {
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP "d" CONFIGFILENAME, srb2home);
-			else
+			} else {
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP CONFIGFILENAME, srb2home);
+				snprintf(configfile_radio, sizeof configfile_radio, "%s" PATHSEP RADIOCONFIGFILENAME, srb2home);
+			}
 
 			// can't use sprintf since there is %u in savegamename
 			strcatbf(savegamename, srb2home, PATHSEP);
@@ -1661,10 +1668,12 @@ void D_SRB2Main(void)
 			snprintf(luafiledir, sizeof luafiledir, "%s" PATHSEP "luafiles", srb2home);
 #else // DEFAULTDIR
 			snprintf(srb2home, sizeof srb2home, "%s", userhome);
-			if (dedicated)
+			if (dedicated) {
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP "d"CONFIGFILENAME, userhome);
-			else
+			} else {
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP CONFIGFILENAME, userhome);
+				snprintf(configfile_radio, sizeof configfile_radio, "%s" PATHSEP RADIOCONFIGFILENAME, userhome);
+			}
 
 			// can't use sprintf since there is %u in savegamename
 			strcatbf(savegamename, userhome, PATHSEP);
@@ -1675,6 +1684,7 @@ void D_SRB2Main(void)
 		}
 
 		configfile[sizeof configfile - 1] = '\0';
+		configfile_radio[sizeof configfile_radio - 1] = '\0';
 	}
 
 	// If config isn't writable, tons of behavior will be broken.

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -7518,7 +7518,7 @@ static void K_drawKartStartCountdown(void)
 
 	if (leveltime >= introtime && leveltime < starttime-(3*TICRATE))
 	{
-		if (!cv_hud_hideposition.value)
+		if (cv_hud_hideposition.value)
 			return;
 		
 		if (numbulbs > 1)
@@ -7527,7 +7527,7 @@ static void K_drawKartStartCountdown(void)
 	else
 	{
 
-		if (!cv_hud_hidecountdown.value)
+		if (cv_hud_hidecountdown.value)
 			return;
 
 		if (leveltime >= starttime-(2*TICRATE)) // 2

--- a/src/m_misc.cpp
+++ b/src/m_misc.cpp
@@ -544,6 +544,7 @@ void M_LoadJoinedIPs(void)
 //
 
 char configfile[MAX_WADPATH];
+char configfile_radio[MAX_WADPATH];
 
 // ==========================================================================
 //                          CONFIGURATION
@@ -683,6 +684,9 @@ void M_FirstLoadConfig(void)
 		COM_BufAddText (va("%s \"%s\"\n",cv_playercolor[i].name,cv_playercolor[i].defaultvalue));
 	}
 #endif
+
+	// Load the Radio config
+	COM_BufInsertText(va("exec \"%s\" -immediate\n", configfile_radio));
 }
 
 /** Saves the game configuration.
@@ -781,6 +785,47 @@ void M_SaveConfig(const char *filename)
 		catch (const fs::filesystem_error& ex)
 		{
 			CONS_Alert(CONS_ERROR, M_GetText("Failed to move temp config file to real destination\n"));
+		}
+	}
+
+	// Radio custom config file
+	if (!filename && !dedicated) {
+		FILE *cf;
+		char custom_tmppath[2048];
+
+		// The earlier else-conditional is triggered whenever the game quits, which is when the custom config should be saved.
+		sprintf(custom_tmppath, "%s.tmp", configfile_radio);
+
+		cf = fopen(custom_tmppath, "w");
+		if (!cf)
+		{
+			CONS_Alert(CONS_ERROR, M_GetText("Couldn't save Radio config file %s\n"), configfile_radio);
+			return;
+		}
+
+		// header message
+		fprintf(cf, "// RadioRacers configuration file.\n");
+
+		// Save the Radio-only cvars
+		CV_SaveRadioVariables(cf);
+		fclose(cf);
+
+		{
+			// Atomically replace the old config once the new one has been written.
+
+			namespace fs = std::filesystem;
+
+			fs::path custom_tmp{custom_tmppath};
+			fs::path custom_real{configfile_radio};
+
+			try
+			{
+				fs::rename(custom_tmp, custom_real);
+			}
+			catch (const fs::filesystem_error& ex)
+			{
+				CONS_Alert(CONS_ERROR, M_GetText("Failed to move temp Radio config file to real destination\n"));
+			}
 		}
 	}
 }

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -65,6 +65,7 @@ void M_StopMovie(void);
 
 // the file where game vars and settings are saved
 #define CONFIGFILENAME "ringconfig.cfg"
+#define RADIOCONFIGFILENAME "radioconfig.cfg"
 
 // The file where we'll save the last IPs we joined
 #define IPLOGFILE "ringsavedips.txt"
@@ -170,6 +171,9 @@ const char * M_Ftrim (double);
 FUNCMATH UINT8 M_CountBits(UINT32 num, UINT8 size);
 
 extern char configfile[MAX_WADPATH];
+
+// Radio
+extern char configfile_radio[MAX_WADPATH];
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
Save all build-related cvars into a separate configuration file — `radioconfig.cfg`.

Closes #37.