### PR TITLE
fix Riders Finish Ticker setting not working

### DIFF
--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -583,7 +583,7 @@ consvar_t cv_gingeritemtimersoffset = Player("huditemtimersoffset", "0").floatin
 consvar_t cv_powersound = Player("powersoundhc", "Off").on_off().radio();
 consvar_t cv_powersoundjoke = Player("powersoundjokehc", "On").on_off().onchange_noinit(KartExtraPowerSound_OnChange).radio();
 
-consvar_t cv_show_riders_finish_ticker = Player("ridersfinishticker", "On").on_off().onchange_noinit(KartFinishLineTicker_OnChange);
+consvar_t cv_show_riders_finish_ticker = Player("ridersfinishticker", "On").on_off().onchange_noinit(KartFinishLineTicker_OnChange).radio();
 
 // Rumble Events
 consvar_t cv_morerumbleevents = Player("morerumbleevents", "On").on_off().onchange(RumbleEvents_OnChange).radio();

--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -583,7 +583,7 @@ consvar_t cv_gingeritemtimersoffset = Player("huditemtimersoffset", "0").floatin
 consvar_t cv_powersound = Player("powersoundhc", "Off").on_off().radio();
 consvar_t cv_powersoundjoke = Player("powersoundjokehc", "On").on_off().onchange_noinit(KartExtraPowerSound_OnChange).radio();
 
-consvar_t cv_show_riders_finish_ticker = Player("ridersfinishticker", "On").on_off().onchange_noinit(KartFinishLineTicker_OnChange).radio();
+consvar_t cv_show_riders_finish_ticker = Player("ridersfinishticker", "On").on_off().onchange_noinit(KartFinishLineTicker_OnChange);
 
 // Rumble Events
 consvar_t cv_morerumbleevents = Player("morerumbleevents", "On").on_off().onchange(RumbleEvents_OnChange).radio();

--- a/src/radioracers/hud/rr_hud.cpp
+++ b/src/radioracers/hud/rr_hud.cpp
@@ -382,7 +382,7 @@ void RR_addPlayerToFinshTicker(player_t *player)
 
 void RR_ridersFinishTick(void)
 {
-    if (playerFinishTickerQueue.empty()) return;
+    if (playerFinishTickerQueue.empty() || !cv_show_riders_finish_ticker.value) return;
     
     // Move over to the left
     playerFinishTickerQueue.front().x -= 2;
@@ -423,7 +423,7 @@ static const int FINISH_TICKER_Y = 45;
  */
 void RR_drawRidersFinishTicker(void)
 {
-    if (playerFinishTickerQueue.empty()) return;
+    if (playerFinishTickerQueue.empty() || !cv_show_riders_finish_ticker.value) return;
 
     patch_t *lapFlag = static_cast<patch_t*>(W_CachePatchName("K_SPTLAP", GTC_CACHE));
 


### PR DESCRIPTION
apparently the setting to disable the riders ticker wasn't working before, only when you disabled it in the midst of getting displayed did it work. first time submitting a bugfix for radioracers so I might have gotten something wrong