### PR TITLE
Allow disabling S rank voiceline

### DIFF
--- a/src/radioracers/hud/rr_setup.cpp
+++ b/src/radioracers/hud/rr_setup.cpp
@@ -1005,7 +1005,8 @@ void RR_Init(void) {
         radio_last_powerup_jingle_sound = S_AddSoundFx("pujvlj", false, 0, false);
 
         // S Ranks
-        radio_s_rank_voiceline = S_AddSoundFx("srankl", false, 0, false);
+        if (W_LumpExists("DSSRANKL"))
+            radio_s_rank_voiceline = S_AddSoundFx("srankl", false, 0, false);
 
         // Perfect boost
         radio_perfectboost_line = S_AddSoundFx("rrpfst", false, 0, false);


### PR DESCRIPTION
I was under the expectation that the additional sound files in radioracers.pk3 could be deleted since they were for optional features (e.g. a join sound) or just entirely cosmetic sound replacements, however out of these sound files it seems you cannot do the same with the S rank meme voiceline as it defaults to the thok sound instead. So, this change is for that so that you can hear your character's regular win sound if you delete SRANKL.ogg. Felt like submitting this after I did the bug fix just now