### PR TITLE
add new HUD setting: "Display Delay Counter Beside FPS"

### DIFF
--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -690,6 +690,8 @@ consvar_t cv_hud_hidelapemblem = Player("hidelapemblem", "Off").on_off().radio()
 consvar_t cv_hud_usehighresportraits = Player("usehighresportraits", "Yes").yes_no().radio();
 // Toggle a more compact version of the details in the bottom-left of the HUD for races
 consvar_t cv_hud_compact = Player("usecompacthud", "No").yes_no().radio();
+// Display delay counter beside FPS counter
+consvar_t cv_hud_displaypingbesideticrate = Player("displaypingbesideticrate", "Yes").yes_no().radio();
 // Restore SRB2Kart behaviour when viewing in-game rankings (i.e. having to hold the button)
 consvar_t cv_holdbuttonforscoreboard = Player("holdbuttonforscoreboard", "No").yes_no().radio();
 // Toggle between ANALOG and DIGITAL input display

--- a/src/radioracers/menus/rr_menus.c
+++ b/src/radioracers/menus/rr_menus.c
@@ -222,6 +222,9 @@ menuitem_t OPTIONS_RadioRacersHud[] =
 	{IT_STRING | IT_CVAR, "Use Higher Resolution Portraits", "Draw higher resolution portraits in the minirankings.",
 		NULL, {.cvar = &cv_hud_usehighresportraits}, 0, 0},
 
+	{IT_STRING | IT_CVAR, "Display Delay Counter Beside FPS", "Toggle if the delay counter should be displayed next to the FPS counter.",
+		NULL, {.cvar = &cv_hud_displaypingbesideticrate}, 0, 0},
+
 	{IT_HEADER, "Roulette Options", NULL,
 		NULL, {NULL}, 0, 0},
 

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -88,6 +88,7 @@ extern consvar_t cv_hud_hideposition;  // Hide the bigass position bulbs at the 
 extern consvar_t cv_hud_hidelapemblem; // Hide the bigass lap emblem when you start a new lap
 extern consvar_t cv_hud_usehighresportraits; // Draw higher-res portraits in the minirankings
 extern consvar_t cv_hud_compact; // Toggle a slightly more compact HUD
+extern consvar_t cv_hud_displaypingbesideticrate; // Display delay counter beside FPS counter
 extern consvar_t cv_holdbuttonforscoreboard; // Restore SRB2Kart behaviour when viewing in-game scoreboards
 extern consvar_t cv_inputdisplaytoggle; // Toggle betweeen DIGITAL and ANALOG input display controller
 extern consvar_t cv_inputdisplaytogglesize; // Toggle controller display size (mini or big)

--- a/src/screen.c
+++ b/src/screen.c
@@ -535,7 +535,7 @@ void SCR_DisplayTicRate(void)
 	UINT32 benchmark = (cap == 0) ? I_GetRefreshRate() : cap;
 	INT32 x = 317;
 	const boolean isActuallyDrawingInput = isDrawingInput && cv_inputdisplaytogglesize.value;
-	const boolean isDrawingPing = isPingDrawn && r_splitscreen == 0;
+	const boolean isDrawingPing = isPingDrawn && cv_hud_displaypingbesideticrate.value && r_splitscreen == 0;
 
 	if (isDrawingPing)
 	{
@@ -598,16 +598,21 @@ void SCR_DisplayLocalPing(void)
 	UINT32 mindelay = playerdelaytable[consoleplayer];
 	UINT32 ping = playerpingtable[consoleplayer];
 	UINT32 pl = playerpacketlosstable[consoleplayer];
-	
-	// RADIO: To the side looks cleaner then showing it vertically
-	// INT32 dispy = cv_ticrate.value ? 170 : 181;
-	INT32 dispy = 189;
-	INT32 dispx = 298;
 
-	if (isDrawingInput && cv_inputdisplaytogglesize.value)
-		dispx = 270;
+	INT32 dispx = 307;
+	INT32 dispy = cv_ticrate.value ? 170 : 181;
 
-	HU_drawPing(dispx * FRACUNIT, dispy * FRACUNIT, ping, mindelay, pl, V_SNAPTORIGHT | V_SNAPTOBOTTOM, 1);
+	if (cv_hud_displaypingbesideticrate.value)
+	{
+		// RADIO: To the side looks cleaner then showing it vertically
+		dispy = 189;
+		dispx = 298;
+
+		if (isDrawingInput && cv_inputdisplaytogglesize.value)
+			dispx = 270;
+	}
+
+	HU_drawPing(dispx * FRACUNIT, dispy * FRACUNIT, ping, mindelay, pl, V_SNAPTORIGHT | V_SNAPTOBOTTOM, cv_hud_displaypingbesideticrate.value ? 1 : 0);
 }
 
 


### PR DESCRIPTION
adds a setting to revert the delay counter to how it's displayed in vanilla ring racers (i.e. above the fps counter)

[ringracers0107.webm](https://github.com/user-attachments/assets/f4a7dc81-f699-4216-9d8b-50676b33cbdb)
