### PR TITLE
add new HUD setting: Power-Up Counter Position

### DIFF
--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -637,6 +637,12 @@ consvar_t cv_customemeraldhud = Player("customemeraldhud", "Full").values({
 	{2, "Full"}
 }).radio();
 
+// Display Combat UFO Power-Ups on the bottom of the screen
+consvar_t cv_poweruponbottom = Player("poweruponbottom", "Bottom").values({
+	{0, "Vanilla"}, 
+	{1, "Bottom"}
+}).radio();
+
 // Toggle Winner announcement at end of the round
 consvar_t cv_battle_toggle_winner_announcement = Player("bttl_toggle_winner_announcement", "On").on_off().radio();
 

--- a/src/hud/powerup.cpp
+++ b/src/hud/powerup.cpp
@@ -90,11 +90,17 @@ void K_drawKartPowerUps(void)
 	{
 		auto make_drawer = [](int x, int y, Draw::Font font) -> Draw
 		{
-			return Draw(x, y).font(font).align(Draw::Align::kRight)
-				// RadioRacers: interception ...
-				.flags(V_SLIDEIN|V_SNAPTOBOTTOM)
-				.scale(0.8);
-				// ... ends here
+			// RadioRacers
+			if (cv_poweruponbottom.value)
+			{
+				return Draw(x, y).font(font).align(Draw::Align::kRight)
+					.flags(V_SLIDEIN|V_SNAPTOBOTTOM)
+					.scale(0.8);
+			}
+			else
+			{
+				return Draw(x, y).font(font).align(Draw::Align::kRight).flags(V_SLIDEIN);
+			}
 		};
 
 		const int viewnum = R_GetViewNumber();
@@ -103,15 +109,11 @@ void K_drawKartPowerUps(void)
 		switch (r_splitscreen)
 		{
 		case 0:
-			/**
-			 * RadioRacers: This SHOULD be gated with a cvar conditional. 
-			 * And it might be in the future.
-			 * But it's such a braindead QOL change that it makes more sense to force it.
-			 * 
-			 * Original line above.
-			 */
-
-			return { make_drawer(175, 190, Draw::Font::kZVote), "PWRU", -13, 7, -28, -1 };
+			// RadioRacers
+			if (cv_poweruponbottom.value)
+				return { make_drawer(175, 190, Draw::Font::kZVote), "PWRU", -13, 7, -28, -1 };
+			else
+				return { make_drawer(307, 58, Draw::Font::kZVote), "PWRU", -17, 7, -35, -1 };
 
 		case 1:
 			return { make_drawer(318, viewnum == 0 ? 58 : 147, Draw::Font::kPing), "PWRS", -9, 6, -19, -1 };
@@ -146,13 +148,22 @@ void K_drawKartPowerUps(void)
 	srb2::StaticVec<Icon, NUMPOWERUPS> powerup_list = get_powerup_list(i.dir == -1);
 	for (const Icon& ico : powerup_list)
 	{
-		i.row.xy(i.spr_x, i.spr_y)
-			.colormap(static_cast<skincolornum_t>(stplyr->skincolor))
-		// RadioRacers: interception ...
-			.scale(0.4)
-			.flags(V_SNAPTOBOTTOM)
-		// ... ends here
-			.patch(fmt::format("{0}{1:c}L{1:c}R", i.sprite, ico.letter()).c_str());
+		// RadioRacers
+		if (cv_poweruponbottom.value)
+		{
+			i.row.xy(i.spr_x, i.spr_y)
+				.colormap(static_cast<skincolornum_t>(stplyr->skincolor))
+				.scale(0.4)
+				.flags(V_SNAPTOBOTTOM)
+				.patch(fmt::format("{0}{1:c}L{1:c}R", i.sprite, ico.letter()).c_str());
+		}
+		else
+		{
+			i.row.xy(i.spr_x, i.spr_y)
+				.colormap(static_cast<skincolornum_t>(stplyr->skincolor))
+				.patch(fmt::format("{0}{1:c}L{1:c}R", i.sprite, ico.letter()).c_str());
+		}
+			
 		i.row.text("{}", (ico.time + (TICRATE / 2)) / TICRATE);
 		i.row = i.row.x(i.shift_x);
 	}

--- a/src/radioracers/menus/rr_menus.c
+++ b/src/radioracers/menus/rr_menus.c
@@ -83,6 +83,9 @@ static menuitem_t OPTIONS_RadioRacersHudBattle[] =
 	{IT_STRING | IT_CVAR, "Sphere Gauge Position", "Toggle the Sphere Gauge's HUD position.",
 		NULL, {.cvar = &cv_spheremeteronplayer}, 0, 0},
 
+	{IT_STRING | IT_CVAR, "Power-Up Counter Position", "Toggle the HUD position of the Combat UFO Power-Up counter.",
+		NULL, {.cvar = &cv_poweruponbottom}, 0, 0},
+
 	{IT_STRING | IT_CVAR, "Emerald HUD", "Toggle an alternate take on the Emerald display in the HUD.",
 		NULL, {.cvar = &cv_customemeraldhud}, 0, 0},
 

--- a/src/radioracers/rr_cvar.h
+++ b/src/radioracers/rr_cvar.h
@@ -45,6 +45,7 @@ extern consvar_t cv_precise_countdown;              // Show a little bar below s
 // Battle
 extern consvar_t cv_customemeraldhud;    // Alternate Emerald display for Battle Mode
 extern consvar_t cv_spheremeteronplayer; // Blue Sphere meter drawn on player
+extern consvar_t cv_poweruponbottom; // Display Power-Up counter on the bottom of the screen
 
 // Battle - HUD Tracking
 extern consvar_t cv_targetrackplayers;  // Toggle the TARGET HUD graphics for other players


### PR DESCRIPTION
adds setting to set battle power-up counter display to what it normally looks like in vanilla. doesn't affect the global item timers setting as it will still display on the bottom as usual

[ringracers0111.webm](https://github.com/user-attachments/assets/56eb2534-9b79-450f-8925-ef45ef935fe4)
