### PR TITLE
add setting to change size of position number back to vanilla

### DIFF
--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -709,8 +709,12 @@ consvar_t cv_inputdisplaytogglesize = Player("inputdisplaytogglesize", "Mini").v
 	{0, "Normal"}, 
 	{1, "Mini"}
 }).radio();
+consvar_t cv_toggle_position_number = Player("positionnumbertoggle", "Small").values({
+	{0, "Vanilla"}, 
+	{1, "Small"},
+	{2, "Off"}
+}).radio();
 
-consvar_t cv_toggle_position_number = Player("positionnumbertoggle", "On").on_off().radio();
 consvar_t cv_toggle_race_minimap = Player("raceminimaptoggle", "On").on_off().radio();
 consvar_t cv_toggle_trick_cool = Player("tricktexttoggle", "On").on_off().radio();
 consvar_t cv_toggle_race_standings = Player("racestandingstoggle", "On").on_off().radio();

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -2949,8 +2949,12 @@ void K_DrawKartPositionNumXY(
 static void K_DrawKartPositionNum(UINT8 num)
 {
 	UINT8 splitIndex = (r_splitscreen > 0) ? 1 : 0;
+	fixed_t scale = FRACUNIT;
+
 	// RADIO: It's pretty big already
-	fixed_t scale = FRACUNIT/2;
+	if (cv_toggle_position_number.value == 1)
+		scale = FRACUNIT/2;
+
 	fixed_t fx = 0, fy = 0;
 	transnum_t trans = static_cast<transnum_t>(0);
 	INT32 fflags = 0;
@@ -2982,7 +2986,9 @@ static void K_DrawKartPositionNum(UINT8 num)
 	{
 		const boolean isDrawingInput = gamestate == GS_LEVEL && cv_drawinput.value && cv_inputdisplaytogglesize.value;
 		fx = BASEVIDWIDTH << FRACBITS;
-		fy = (BASEVIDHEIGHT - (isDrawingInput ? 14 : 10)) << FRACBITS;
+		fy = BASEVIDHEIGHT << FRACBITS;
+		if (cv_toggle_position_number.value == 1)
+			fy = (BASEVIDHEIGHT - (isDrawingInput ? 14 : 10)) << FRACBITS;
 		fflags = V_SNAPTOBOTTOM|V_SNAPTORIGHT;
 	}
 	else if (r_splitscreen == 1)	// for this splitscreen, we'll use case by case because it's a bit different.
@@ -9431,7 +9437,7 @@ void K_drawKartHUD(void)
 						}
 					}
 				}
-				else if (!islonesome && !K_Cooperative() && cv_toggle_position_number.value)
+				else if (!islonesome && !K_Cooperative() && cv_toggle_position_number.value < 2)
 				{
 					K_DrawKartPositionNum(stplyr->position);
 				}

--- a/src/radioracers/menus/rr_menus.c
+++ b/src/radioracers/menus/rr_menus.c
@@ -23,6 +23,12 @@ static menuitem_t OPTIONS_RadioRacersHudRace[] =
 {
 	{IT_STRING | IT_CVAR, "Compact HUD Details", "Toggle compact player information in the HUD (bottom-left).",
 		NULL, {.cvar = &cv_hud_compact}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Position Number", "Change how the bottom-right position number is displayed.",
+		NULL, {.cvar = &cv_toggle_position_number}, 0, 0},   
+
+	{IT_SPACE | IT_NOTHING, NULL,  NULL,
+		NULL, {NULL}, 0, 0},
 	
 	{IT_HEADER, "Toggle HUD Elements", NULL,
 		NULL, {NULL}, 0, 0},
@@ -32,9 +38,6 @@ static menuitem_t OPTIONS_RadioRacersHudRace[] =
 		
 	{IT_STRING | IT_CVAR, "EXP on Split", "Show/hide EXP gained during checkpoint splits.",
 		NULL, {.cvar = &cv_showexponsplit}, 0, 0},   
-		
-	{IT_STRING | IT_CVAR, "Position Number", "Toggle position number on the bottom-right.",
-		NULL, {.cvar = &cv_toggle_position_number}, 0, 0},   
 
 	{IT_STRING | IT_CVAR, "Minimap", "Hide the minimap.",
 		NULL, {.cvar = &cv_toggle_race_minimap}, 0, 0},   


### PR DESCRIPTION
chanegs the "toggle position number" setting to allow changing the size of the position number display to its original vanilla size and its smaller size from radioracers, as well as keeping the option to disable it altogether

[ringracers0108.webm](https://github.com/user-attachments/assets/b9fd9e06-fd5a-4aaf-81ef-cc44fa34aaa2)
