### PR TITLE
Fix improper level names for vote snitching

### DIFF
--- a/src/radioracers/netgame/rr_votesnitch.c
+++ b/src/radioracers/netgame/rr_votesnitch.c
@@ -26,7 +26,7 @@ boolean RR_UseVoteSnitch(void)
 void RR_VoteSnitchNewVote(midVoteType_e type, player_t *victim, player_t *caller)
 {
     const char *voteReason;
-	const char *levelTitle = mapheaderinfo[gamemap-1]->lvlttl;
+	const char *levelTitle = G_BuildMapTitle(gamemap);
 	switch (type){
 		case MVT_KICK: // Kick
 			voteReason = va("\x82KICK \x89%s\x86", player_names[victim - players]);


### PR DESCRIPTION
yea so radioracers did this by mistake oops

before
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/0660b9ce-c6f7-4230-afe2-4e9feab3a564" />

after
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/f23997d9-a5f3-4349-af3d-cac29643a43d" />
